### PR TITLE
Fix out of bounds / add new option txtVoffset

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -2,6 +2,7 @@ VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
 
 - [pbiering] introduce setup option "Text Vertical Offset" ("5" looks good on softhddevice)
+- [pbiering] fix out-of-bounds message by using new way to calculated x/y position for ClearMessage
 
 - [pbiering] merge fix for issues fond with OpenGL
 	https://www.vdr-portal.de/forum/index.php?thread/133952-softhddevice-bug-in-opengl-osd-bug-mit-osdteletext/

--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,13 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
 
+- [pbiering] merge fix for issues fond with OpenGL
+	https://www.vdr-portal.de/forum/index.php?thread/133952-softhddevice-bug-in-opengl-osd-bug-mit-osdteletext/
+
+- [pbiering] merge fix for annoying blank lines in graphics characters
+	https://www.vdr-portal.de/index.php?attachment/41771-osdteletext-0-9-7-patch/
+        https://www.vdr-portal.de/forum/index.php?thread/131627-gel%C3%B6st-vdr-plugin-osdteletxt-0-9-7/&postID=1303329#post1303329
+
 - [pbiering] add configurable 4bpp color mode base on hardcoded patch:
 	https://www.vdr-portal.de/index.php?attachment/41884-osdteletext-4bpp-diff/
 	https://www.vdr-portal.de/forum/index.php?thread/131627-gel%C3%B6st-vdr-plugin-osdteletxt-0-9-7/&postID=1304681#post1304681

--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,8 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
 
+- [pbiering] introduce setup option "Text Vertical Offset" ("5" looks good on softhddevice)
+
 - [pbiering] merge fix for issues fond with OpenGL
 	https://www.vdr-portal.de/forum/index.php?thread/133952-softhddevice-bug-in-opengl-osd-bug-mit-osdteletext/
 

--- a/README
+++ b/README
@@ -1,10 +1,10 @@
 This is a "plugin" for the Video Disk Recorder (VDR).
 
-Written by:                  Marcel Wiesweg <marcel.wiesweg@gmx.de>
+Initially Written by:                   Marcel Wiesweg <marcel.wiesweg@gmx.de>
 
-Project's homepage:          http://www.wiesweg-online.de/linux/vdr
+Original Project's homepage (EOSL):     http://www.wiesweg-online.de/linux/vdr
 
-Latest version available at: http://projects.vdr-developer.org/projects/show/plg-osdteletext
+Latest version available at: https://github.com/vdr-projects/vdr-plugin-osdteletex
 
 See the file COPYING for license information.
 

--- a/displaybase.c
+++ b/displaybase.c
@@ -503,12 +503,13 @@ void cDisplay::DrawMessage(const char *txt) {
     // Draw text
     osd->DrawText(x+2*border,y+2*border,txt, fg, bg, MessageFont);
 
-
     // Remember box
     MessageW=w;
     MessageH=h;
     MessageX=x;
     MessageY=y;
+
+    dsyslog("OSD-Teletext/%s: display with MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY);
 
     // And flush all changes
     ReleaseFlush();
@@ -526,20 +527,24 @@ void cDisplay::ClearMessage() {
     int x1=(MessageX+MessageW-1-OffsetX)*ScaleX+ScaleX/2;
     int y1=(MessageY+MessageH-1-OffsetY)*ScaleY+ScaleY/2;
 
+    dsyslog("OSD-Teletext/%s: calculated virtual coordinates: x0=%d/y0=%d x1=%d/y1=%d", __FUNCTION__, x0, y0, x1, y1);
+
     // map to character
     x0=x0/(12<<16);
     y0=y0/(10<<16);
     x1=(x1+(12<<16)-1)/(12<<16);
     y1=(y1+(10<<16)-1)/(10<<16);
 
+    dsyslog("OSD-Teletext/%s: character          coordinates: x0=%d/y0=%d x1=%d/y1=%d", __FUNCTION__, x0, y0, x1, y1);
+
 #define TESTOORX(X) (X < 0 || X >= 40)
 #define TESTOORY(Y) (Y < 0 || Y >= 25)
     if ( TESTOORX(x0) || TESTOORX(x1) || TESTOORY(y0) || TESTOORY(y1) ) {
 	// something out-of-range
-	esyslog("OSD-Teletext/%s: out-of-range detected(crop) MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d => x0=%d%s x1=%d%s y0=%d%s y1=%d%s", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY,
+	esyslog("OSD-Teletext/%s: out-of-range detected(crop) MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d => x0=%d%s y0=%d%s x1=%d%s y1=%d%s", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY,
 		x0, TESTOORX(x0) ? "!" : "",
-		x1, TESTOORX(x1) ? "!" : "",
 		y0, TESTOORY(y0) ? "!" : "",
+		x1, TESTOORX(x1) ? "!" : "",
 		y1, TESTOORY(y1) ? "!" : ""
 	);
 	// crop to limits

--- a/displaybase.c
+++ b/displaybase.c
@@ -518,7 +518,7 @@ void cDisplay::ClearMessage() {
     if (!osd) return;
     if (MessageW==0 || MessageH==0) return;
 
-    dsyslog("%s/%s: called with MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d", PLUGIN_NAME_I18N, __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY);
+    dsyslog("OSD-Teletext/%s: called with MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY);
 
     // map OSD pixel to virtual coordinate, use center of pixel
     int x0=(MessageX-OffsetX)*ScaleX+ScaleX/2;
@@ -536,7 +536,7 @@ void cDisplay::ClearMessage() {
 #define TESTOORY(Y) (Y < 0 || Y >= 25)
     if ( TESTOORX(x0) || TESTOORX(x1) || TESTOORY(y0) || TESTOORY(y1) ) {
 	// something out-of-range
-	esyslog("%s/%s: out-of-range detected(crop) MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d => x0=%d%s x1=%d%s y0=%d%s y1=%d%s", PLUGIN_NAME_I18N, __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY,
+	esyslog("OSD-Teletext/%s: out-of-range detected(crop) MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d => x0=%d%s x1=%d%s y0=%d%s y1=%d%s", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY,
 		x0, TESTOORX(x0) ? "!" : "",
 		x1, TESTOORX(x1) ? "!" : "",
 		y0, TESTOORY(y0) ? "!" : "",
@@ -552,7 +552,7 @@ void cDisplay::ClearMessage() {
 	if TESTOORY(y0) y0 = 25 - 1;
 	if TESTOORY(y1) y1 = 25 - 1;
     }
-    dsyslog("%s/%s: call MakeDirty with area x0=%d/y0=%d <-> x1=%d/y1=%d", PLUGIN_NAME_I18N, __FUNCTION__, x0, y0, x1, y1);
+    dsyslog("OSD-Teletext/%s: call MakeDirty with area x0=%d/y0=%d <-> x1=%d/y1=%d", __FUNCTION__, x0, y0, x1, y1);
     for (int x=x0;x<=x1;x++) {
         for (int y=y0;y<=y1;y++) {
             MakeDirty(x,y);

--- a/displaybase.c
+++ b/displaybase.c
@@ -509,7 +509,11 @@ void cDisplay::DrawMessage(const char *txt) {
     MessageX=x;
     MessageY=y;
 
+#if 0
     dsyslog("OSD-Teletext/%s: display with MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY);
+#else
+    dsyslog("OSD-Teletext/%s: display with MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY);
+#endif
 
     // And flush all changes
     ReleaseFlush();
@@ -527,13 +531,13 @@ void cDisplay::ClearMessage() {
     int x1=(MessageX+MessageW-1-OffsetX)*ScaleX+ScaleX/2;
     int y1=(MessageY+MessageH-1-OffsetY)*ScaleY+ScaleY/2;
 
-    dsyslog("OSD-Teletext/%s: calculated virtual coordinates: x0=%d/y0=%d x1=%d/y1=%d", __FUNCTION__, x0, y0, x1, y1);
-
     // map to character
     x0=x0/(12<<16);
     y0=y0/(10<<16);
     x1=(x1+(12<<16)-1)/(12<<16);
     y1=(y1+(10<<16)-1)/(10<<16);
+
+    dsyslog("OSD-Teletext/%s: called with MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d => x0=%d/y0=%d x1=%d/y1=%d", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY, x0, y0, x1, y1);
 #else
     // NEW, reverse calculation based on how DrawChar
     // map to character x/y
@@ -541,15 +545,19 @@ void cDisplay::ClearMessage() {
     int y0 = (MessageY-OffsetY)            / (fontHeight / 2);
     int x1 = (MessageX+MessageW-1-OffsetX) / (fontWidth  / 2);
     int y1 = (MessageY+MessageH-1-OffsetY) / (fontHeight / 2);
-#endif
 
-    dsyslog("OSD-Teletext/%s: called with MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d => x0=%d/y0=%d x1=%d/y1=%d", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY, x0, y0, x1, y1);
+    dsyslog("OSD-Teletext/%s: called with MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d => x0=%d/y0=%d x1=%d/y1=%d", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, x0, y0, x1, y1);
+#endif
 
 #define TESTOORX(X) (X < 0 || X >= 40)
 #define TESTOORY(Y) (Y < 0 || Y >= 25)
     if ( TESTOORX(x0) || TESTOORX(x1) || TESTOORY(y0) || TESTOORY(y1) ) {
 	// something out-of-range
+#if 0
 	esyslog("OSD-Teletext/%s: out-of-range detected(crop) MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d => x0=%d%s y0=%d%s x1=%d%s y1=%d%s", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY,
+#else
+	esyslog("OSD-Teletext/%s: out-of-range detected(crop) MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d => x0=%d%s y0=%d%s x1=%d%s y1=%d%s", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY,
+#endif
 		x0, TESTOORX(x0) ? "!" : "",
 		y0, TESTOORY(y0) ? "!" : "",
 		x1, TESTOORX(x1) ? "!" : "",

--- a/displaybase.c
+++ b/displaybase.c
@@ -535,7 +535,7 @@ void cDisplay::ClearMessage() {
     x1=(x1+(12<<16)-1)/(12<<16);
     y1=(y1+(10<<16)-1)/(10<<16);
 
-    dsyslog("OSD-Teletext/%s: character          coordinates: x0=%d/y0=%d x1=%d/y1=%d", __FUNCTION__, x0, y0, x1, y1);
+    dsyslog("OSD-Teletext/%s: calculated charact coordinates: x0=%d/y0=%d x1=%d/y1=%d", __FUNCTION__, x0, y0, x1, y1);
 
 #define TESTOORX(X) (X < 0 || X >= 40)
 #define TESTOORY(Y) (Y < 0 || Y >= 25)

--- a/displaybase.c
+++ b/displaybase.c
@@ -522,6 +522,7 @@ void cDisplay::ClearMessage() {
     dsyslog("OSD-Teletext/%s: called with MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY);
 
 #if 0
+    // BUGGY, resulting in out-of-range
     // map OSD pixel to virtual coordinate, use center of pixel
     int x0=(MessageX-OffsetX)*ScaleX+ScaleX/2;
     int y0=(MessageY-OffsetY)*ScaleY+ScaleY/2;
@@ -536,6 +537,7 @@ void cDisplay::ClearMessage() {
     x1=(x1+(12<<16)-1)/(12<<16);
     y1=(y1+(10<<16)-1)/(10<<16);
 #else
+    // NEW, reverse calculation based on how DrawChar
     // map to character x/y
     int x0 = (MessageX - OffsetX )         / (fontWidth  / 2);
     int y0 = (MessageY-OffsetY)            / (fontHeight / 2);

--- a/displaybase.c
+++ b/displaybase.c
@@ -519,8 +519,6 @@ void cDisplay::ClearMessage() {
     if (!osd) return;
     if (MessageW==0 || MessageH==0) return;
 
-    dsyslog("OSD-Teletext/%s: called with MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY);
-
 #if 0
     // BUGGY, resulting in out-of-range
     // map OSD pixel to virtual coordinate, use center of pixel
@@ -545,7 +543,7 @@ void cDisplay::ClearMessage() {
     int y1 = (MessageY+MessageH-1-OffsetY) / (fontHeight / 2);
 #endif
 
-    dsyslog("OSD-Teletext/%s: calculated character coordinates: x0=%d/y0=%d x1=%d/y1=%d", __FUNCTION__, x0, y0, x1, y1);
+    dsyslog("OSD-Teletext/%s: called with MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d => x0=%d/y0=%d x1=%d/y1=%d", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY, x0, y0, x1, y1);
 
 #define TESTOORX(X) (X < 0 || X >= 40)
 #define TESTOORY(Y) (Y < 0 || Y >= 25)
@@ -567,7 +565,7 @@ void cDisplay::ClearMessage() {
 	if TESTOORY(y0) y0 = 25 - 1;
 	if TESTOORY(y1) y1 = 25 - 1;
     }
-    dsyslog("OSD-Teletext/%s: call MakeDirty with area x0=%d/y0=%d <-> x1=%d/y1=%d", __FUNCTION__, x0, y0, x1, y1);
+    // dsyslog("OSD-Teletext/%s: call MakeDirty with area x0=%d/y0=%d <-> x1=%d/y1=%d", __FUNCTION__, x0, y0, x1, y1);
     for (int x=x0;x<=x1;x++) {
         for (int y=y0;y<=y1;y++) {
             MakeDirty(x,y);

--- a/displaybase.c
+++ b/displaybase.c
@@ -521,6 +521,7 @@ void cDisplay::ClearMessage() {
 
     dsyslog("OSD-Teletext/%s: called with MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY);
 
+#if 0
     // map OSD pixel to virtual coordinate, use center of pixel
     int x0=(MessageX-OffsetX)*ScaleX+ScaleX/2;
     int y0=(MessageY-OffsetY)*ScaleY+ScaleY/2;
@@ -534,6 +535,13 @@ void cDisplay::ClearMessage() {
     y0=y0/(10<<16);
     x1=(x1+(12<<16)-1)/(12<<16);
     y1=(y1+(10<<16)-1)/(10<<16);
+#else
+    // map to character x/y
+    int x0 = MessageX / (fontWidth / 2);
+    int x1 = (MessageX+MessageW) / (fontWidth / 2) + 1;
+    int y0 = (MessageY) / (fontHeight / 2);
+    int y1 = (MessageY+MessageH) / (fontHeight / 2) + 1;
+#endif
 
     dsyslog("OSD-Teletext/%s: calculated charact coordinates: x0=%d/y0=%d x1=%d/y1=%d", __FUNCTION__, x0, y0, x1, y1);
 

--- a/displaybase.c
+++ b/displaybase.c
@@ -422,7 +422,7 @@ void cDisplay::DrawChar(int x, int y, cTeletextChar c) {
             cBitmap charBm(w, h, 24);
             charBm.DrawRectangle(0, 0, w, h, bg);
 //            charBm.DrawText(0, 0, buf, fg, bg, font);
-            charBm.DrawText(0, 2, buf, fg, 0, font);
+            charBm.DrawText(0, ttSetup.txtVoffset, buf, fg, 0, font);
             osd->DrawBitmap(vx, vy, charBm);
 #endif
         }

--- a/displaybase.c
+++ b/displaybase.c
@@ -536,7 +536,7 @@ void cDisplay::ClearMessage() {
 #define TESTOORY(Y) (Y < 0 || Y >= 25)
     if ( TESTOORX(x0) || TESTOORX(x1) || TESTOORY(y0) || TESTOORY(y1) ) {
 	// something out-of-range
-    	esyslog("%s/%s: out-of-range detected(crop) MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d => x0=%d%s x1=%d%s y0=%d%s y1=%d%s", PLUGIN_NAME_I18N, __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY,
+	esyslog("%s/%s: out-of-range detected(crop) MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d ScaleX=%d ScaleY=%d => x0=%d%s x1=%d%s y0=%d%s y1=%d%s", PLUGIN_NAME_I18N, __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, ScaleX, ScaleY,
 		x0, TESTOORX(x0) ? "!" : "",
 		x1, TESTOORX(x1) ? "!" : "",
 		y0, TESTOORY(y0) ? "!" : "",

--- a/displaybase.c
+++ b/displaybase.c
@@ -422,7 +422,7 @@ void cDisplay::DrawChar(int x, int y, cTeletextChar c) {
             cBitmap charBm(w, h, 24);
             charBm.DrawRectangle(0, 0, w, h, bg);
 //            charBm.DrawText(0, 0, buf, fg, bg, font);
-            charBm.DrawText(0, 0, buf, fg, 0, font);
+            charBm.DrawText(0, 2, buf, fg, 0, font);
             osd->DrawBitmap(vx, vy, charBm);
 #endif
         }

--- a/displaybase.c
+++ b/displaybase.c
@@ -537,13 +537,13 @@ void cDisplay::ClearMessage() {
     y1=(y1+(10<<16)-1)/(10<<16);
 #else
     // map to character x/y
-    int x0 = MessageX / (fontWidth / 2);
-    int x1 = (MessageX+MessageW) / (fontWidth / 2) + 1;
-    int y0 = (MessageY) / (fontHeight / 2);
-    int y1 = (MessageY+MessageH) / (fontHeight / 2) + 1;
+    int x0 = (MessageX - OffsetX )         / (fontWidth  / 2);
+    int y0 = (MessageY-OffsetY)            / (fontHeight / 2);
+    int x1 = (MessageX+MessageW-1-OffsetX) / (fontWidth  / 2);
+    int y1 = (MessageY+MessageH-1-OffsetY) / (fontHeight / 2);
 #endif
 
-    dsyslog("OSD-Teletext/%s: calculated charact coordinates: x0=%d/y0=%d x1=%d/y1=%d", __FUNCTION__, x0, y0, x1, y1);
+    dsyslog("OSD-Teletext/%s: calculated character coordinates: x0=%d/y0=%d x1=%d/y1=%d", __FUNCTION__, x0, y0, x1, y1);
 
 #define TESTOORX(X) (X < 0 || X >= 40)
 #define TESTOORY(Y) (Y < 0 || Y >= 25)

--- a/menu.c
+++ b/menu.c
@@ -654,7 +654,9 @@ TeletextSetup::TeletextSetup()
     //after the plugin has stored its own value.
     inactivityTimeout(Setup.MinUserInactivity),
     HideMainMenu(false),
-    txtFontName("teletext2:Medium")
+    txtFontName("teletext2:Medium"),
+    txtVoffset(0),
+    colorMode4bpp(false)
 {
    //init key bindings
    for (int i=0;i<10;i++)

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -293,7 +293,7 @@ bool cPluginTeletextosd::SetupParse(const char *Name, const char *Value)
      }
 
      //for migration to 0.4
-     char act[7];
+     char act[8];
      strncpy(act, Name, 7);
      if (!strcasecmp(act, "Action_"))
         return true;

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -277,6 +277,7 @@ bool cPluginTeletextosd::SetupParse(const char *Name, const char *Value)
   else if (!strcasecmp(Name, "txtFontName")) ttSetup.txtFontName=strdup(Value);
   else if (!strcasecmp(Name, "txtG0Block")) ttSetup.txtG0Block=atoi(Value);
   else if (!strcasecmp(Name, "txtG2Block")) ttSetup.txtG2Block=atoi(Value);
+  else if (!strcasecmp(Name, "txtVoffset")) ttSetup.txtVoffset=atoi(Value);
   else if (!strcasecmp(Name, "colorMode4bpp")) ttSetup.colorMode4bpp=atoi(Value);
   else {
      for (int i=0;i<LastActionKey;i++) {
@@ -322,6 +323,7 @@ void cTeletextSetupPage::Store(void) {
    ttSetup.txtFontName=temp.txtFontNames[temp.txtFontIndex];
    ttSetup.txtG0Block=temp.txtG0Block;
    ttSetup.txtG2Block=temp.txtG2Block;
+   ttSetup.txtVoffset=temp.txtVoffset;
    ttSetup.colorMode4bpp=temp.colorMode4bpp;
    //ttSetup.inactivityTimeout=temp.inactivityTimeout;
 
@@ -341,6 +343,7 @@ void cTeletextSetupPage::Store(void) {
    SetupStore("txtFontName", ttSetup.txtFontName);
    SetupStore("txtG0Block", ttSetup.txtG0Block);
    SetupStore("txtG2Block", ttSetup.txtG2Block);
+   SetupStore("txtVoffset", ttSetup.txtVoffset);
    SetupStore("colorMode4bpp", ttSetup.colorMode4bpp);
    //SetupStore("inactivityTimeout", ttSetup.inactivityTimeout);
 }
@@ -384,6 +387,7 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
    temp.txtFontName=ttSetup.txtFontName;
    temp.txtG0Block=ttSetup.txtG0Block;
    temp.txtG2Block=ttSetup.txtG2Block;
+   temp.txtVoffset=ttSetup.txtVoffset;
    temp.colorMode4bpp=ttSetup.colorMode4bpp;
    //temp.inactivityTimeout=ttSetup.inactivityTimeout;
 
@@ -410,6 +414,7 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
    Add(new cMenuEditStraItem(tr("Text Font"), &temp.txtFontIndex, temp.txtFontNames.Size(), &temp.txtFontNames[0]));
    Add(new cMenuEditStraItem(tr("G0 code block"), &temp.txtG0Block, NUMELEMENTS(temp.txtBlock), temp.txtBlock));
    Add(new cMenuEditStraItem(tr("G2 code block"), &temp.txtG2Block, NUMELEMENTS(temp.txtBlock), temp.txtBlock));
+   Add(new cMenuEditIntItem(tr("Text Vertical Offset"), &temp.txtVoffset, 0, 10));
    Add(new cMenuEditBoolItem(tr("Color Mode 4bpp"), &temp.colorMode4bpp));
 
    //Using same string as VDR's setup menu

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-01-27 06:22+0100\n"
+"POT-Creation-Date: 2021-01-30 08:26+0100\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Klaus Schmidinger <Klaus.Schmidinger@tvdr.de>\n"
 "Language-Team: German <vdr@linuxtv.org>\n"
@@ -105,6 +105,9 @@ msgstr ""
 
 msgid "G2 code block"
 msgstr ""
+
+msgid "Text Vertical Offset"
+msgstr "Text vertikaler Offset"
 
 msgid "Color Mode 4bpp"
 msgstr "Farbmodus 4bpp"

--- a/setup.h
+++ b/setup.h
@@ -51,6 +51,7 @@ public:
    int txtFontIndex;
    int txtG0Block;
    int txtG2Block;
+   int txtVoffset;
    const char *txtBlock[11];
    int colorMode4bpp;
 };

--- a/txtrender.h
+++ b/txtrender.h
@@ -17,6 +17,7 @@
 #define OSDTELETEXT_TXTRENDER_H_
 
 #include <stdio.h>
+#include <vdr/tools.h>
 
 
 // Teletext character sets
@@ -253,7 +254,7 @@ public:
     cTeletextChar GetChar(int x, int y) {
         // Read character content from page
         if (x<0 || x>=40 || y<0 || y>=25) {
-            printf("Warning: out of bounds read access to teletext page\n");
+            esyslog("%s/%s: Warning: out of bounds read access to teletext page (GetChar, x=%d, y=%d)", PLUGIN_NAME_I18N, __FUNCTION__, x, y);
             return cTeletextChar();
         }
         return Page[x][y].ToDirty(false);
@@ -267,7 +268,7 @@ public:
     bool IsDirty(int x, int y) {
         // local dirty status
         if (x<0 || x>=40 || y<0 || y>=25) {
-            printf("Warning: out of bounds read access to teletext page\n");
+            esyslog("%s/%s: Warning: out of bounds read access to teletext page (IsDirty, x=%d, y=%d)", PLUGIN_NAME_I18N, __FUNCTION__, x, y);
             return false;
         }
         return Page[x][y].GetDirty() | DirtyAll;    
@@ -276,7 +277,7 @@ public:
     void MakeDirty(int x, int y) {
         // force one character dirty
         if (x<0 || x>=40 || y<0 || y>=25) {
-            printf("Warning: out of bounds write access to teletext page\n");
+            esyslog("%s/%s: Warning: out of bounds write access to teletext page (MakeDirty, x=%d, y=%d)", PLUGIN_NAME_I18N, __FUNCTION__, x, y);
             return;
         }
         Page[x][y].SetDirty(true);
@@ -287,7 +288,7 @@ public:
         // Set character at given location
         
         if (x<0 || x>=40 || y<0 || y>=25) {
-            printf("Warning: out of bounds write access to teletext page\n");
+            esyslog("%s/%s: Warning: out of bounds write access to teletext page (SetChar, x=%d, y=%d, c=%x)", PLUGIN_NAME_I18N, __FUNCTION__, x, y, c.GetC());
             return;
         }
         if (GetChar(x,y) != c) {

--- a/txtrender.h
+++ b/txtrender.h
@@ -254,7 +254,7 @@ public:
     cTeletextChar GetChar(int x, int y) {
         // Read character content from page
         if (x<0 || x>=40 || y<0 || y>=25) {
-            esyslog("%s/%s: Warning: out of bounds read access to teletext page (GetChar, x=%d, y=%d)", PLUGIN_NAME_I18N, __FUNCTION__, x, y);
+            esyslog("OSD-Teletext/%s: Warning: out of bounds read access to teletext page (GetChar, x=%d, y=%d)", __FUNCTION__, x, y);
             return cTeletextChar();
         }
         return Page[x][y].ToDirty(false);
@@ -268,7 +268,7 @@ public:
     bool IsDirty(int x, int y) {
         // local dirty status
         if (x<0 || x>=40 || y<0 || y>=25) {
-            esyslog("%s/%s: Warning: out of bounds read access to teletext page (IsDirty, x=%d, y=%d)", PLUGIN_NAME_I18N, __FUNCTION__, x, y);
+            esyslog("OSD-Teletext/%s: Warning: out of bounds read access to teletext page (IsDirty, x=%d, y=%d)", __FUNCTION__, x, y);
             return false;
         }
         return Page[x][y].GetDirty() | DirtyAll;    

--- a/txtrender.h
+++ b/txtrender.h
@@ -277,7 +277,7 @@ public:
     void MakeDirty(int x, int y) {
         // force one character dirty
         if (x<0 || x>=40 || y<0 || y>=25) {
-            esyslog("%s/%s: Warning: out of bounds write access to teletext page (MakeDirty, x=%d, y=%d)", PLUGIN_NAME_I18N, __FUNCTION__, x, y);
+            esyslog("OSD-Teletext/%s: Warning: out of bounds write access to teletext page (MakeDirty, x=%d, y=%d)", __FUNCTION__, x, y);
             return;
         }
         Page[x][y].SetDirty(true);
@@ -288,7 +288,7 @@ public:
         // Set character at given location
         
         if (x<0 || x>=40 || y<0 || y>=25) {
-            esyslog("%s/%s: Warning: out of bounds write access to teletext page (SetChar, x=%d, y=%d, c=%x)", PLUGIN_NAME_I18N, __FUNCTION__, x, y, c.GetC());
+            esyslog("OSD-Teletext/%s: Warning: out of bounds write access to teletext page (SetChar, x=%d, y=%d, c=%x)", __FUNCTION__, x, y, c.GetC());
             return;
         }
         if (GetChar(x,y) != c) {


### PR DESCRIPTION
- introduce setup option "Text Vertical Offset" ("5" looks good on softhddevice)
- fix out-of-bounds message by using new way to calculated x/y position for ClearMessage
- fix a compiler warning
