### PR TITLE
Rework osd size

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,7 +1,7 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
-2021-02-20:
-- [pbiering] add optional percent and always-center based OSD size
+2021-02-23:
+- [pbiering] replace OSD sizing options by percent values and always-centric
 - [pbiering] scale "Text Vertical Offset" according to reduced size
 
 2021-02-19: version 0.9.9

--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,6 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
-2021-02-23:
+2021-02-23: version 1.0.0
 - [pbiering] replace OSD sizing options by percent values and always-centric
 - [pbiering] scale "Text Vertical Offset" according to reduced size
 

--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,9 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
+2021-02-20:
+- [pbiering] add optional percent and always-center based OSD size
+- [pbiering] scale "Text Vertical Offset" according to reduced size
+
 2021-02-19: version 0.9.9
 - [pbiering] add fallback to 8 bpp in case OSD is not supporting TrueColor
 

--- a/display.c
+++ b/display.c
@@ -126,11 +126,12 @@ cDisplay32BPP::cDisplay32BPP(int x0, int y0, int width, int height)
     if (ttSetup.colorMode4bpp == true) {
 	   bpp = 4;
            dsyslog("OSD-Teletext: OSD config forced to bpp=%d", bpp);
-    } else if (osd->IsTrueColor() == false) {
-	   bpp = 8;
-           dsyslog("OSD-Teletext: OSD is not providing TrueColor, fallback to bpp=%d", bpp);
     };
     tArea Areas[] = { { 0, 0, width - 1, height - 1, bpp } };
+    if (bpp == 32 && (osd->CanHandleAreas(Areas, sizeof(Areas) / sizeof(tArea)) != oeOk)) {
+        bpp = 8;
+        dsyslog("OSD-Teletext: OSD is not providing TrueColor, fallback to bpp=%d", bpp);
+    }
     if (osd->CanHandleAreas(Areas, sizeof(Areas) / sizeof(tArea)) != oeOk) {
         DELETENULL(osd);
         esyslog("OSD-Teletext: can't create requested OSD area with x0=%d y0=%d width=%d height=%d bpp=%d", x0, y0, width, height, bpp);

--- a/display.c
+++ b/display.c
@@ -124,12 +124,13 @@ cDisplay32BPP::cDisplay32BPP(int x0, int y0, int width, int height)
 
     int bpp = 32;
     if (ttSetup.colorMode4bpp == true) {
-	   bpp = 4;
-           dsyslog("OSD-Teletext: OSD config forced to bpp=%d", bpp);
+        bpp = 4;
+        dsyslog("OSD-Teletext: OSD config forced to bpp=%d", bpp);
     };
     tArea Areas[] = { { 0, 0, width - 1, height - 1, bpp } };
     if (bpp == 32 && (osd->CanHandleAreas(Areas, sizeof(Areas) / sizeof(tArea)) != oeOk)) {
         bpp = 8;
+        Areas[0].bpp = 8;
         dsyslog("OSD-Teletext: OSD is not providing TrueColor, fallback to bpp=%d", bpp);
     }
     if (osd->CanHandleAreas(Areas, sizeof(Areas) / sizeof(tArea)) != oeOk) {

--- a/display.c
+++ b/display.c
@@ -41,39 +41,31 @@ void Display::SetMode(Display::Mode NewMode) {
     // No change, nothing to do
 
     // OSD origin, centered on VDR OSD
-    if (ttSetup.OSDsizePctMode == true) {
-        // calculate from percentage and OSD maximum
-        OSDwidth = (cOsd::OsdWidth() * ttSetup.OSDwidthPct) / 100;
-        OSDheight = (cOsd::OsdHeight() * ttSetup.OSDheightPct) / 100;
+    // calculate from percentage and OSD maximum
+    OSDwidth = (cOsd::OsdWidth() * ttSetup.OSDwidthPct) / 100;
+    OSDheight = (cOsd::OsdHeight() * ttSetup.OSDheightPct) / 100;
 
-        // apply minimum limit if selected percent values are too less for hpixelPerCharMin/vpixelPerCharMin
-        if (OSDwidth  < (hpixelPerCharMin * hChars)) OSDwidth  = (hpixelPerCharMin * hChars);
-        if (OSDheight < (vpixelPerCharMin * vLines)) OSDheight = (vpixelPerCharMin * vLines);
+    // apply minimum limit if selected percent values are too less for hpixelPerCharMin/vpixelPerCharMin
+    if (OSDwidth  < (hpixelPerCharMin * hChars)) OSDwidth  = (hpixelPerCharMin * hChars);
+    if (OSDheight < (vpixelPerCharMin * vLines)) OSDheight = (vpixelPerCharMin * vLines);
 
-        // align with hChars/vLines in case of less than 100 %
-        if ((ttSetup.OSDwidthPct  < 100) && ((OSDwidth  % hChars) > 0)) OSDwidth  = (OSDwidth  / hChars) * hChars;
-        if ((ttSetup.OSDheightPct < 100) && ((OSDheight % vLines) > 0)) OSDheight = (OSDheight / vLines) * vLines;
+    // align with hChars/vLines in case of less than 100 %
+    if ((ttSetup.OSDwidthPct  < 100) && ((OSDwidth  % hChars) > 0)) OSDwidth  = (OSDwidth  / hChars) * hChars;
+    if ((ttSetup.OSDheightPct < 100) && ((OSDheight % vLines) > 0)) OSDheight = (OSDheight / vLines) * vLines;
 
-        // calculate left/top offset for centering
-        x0 = (cOsd::OsdWidth() - OSDwidth) / 2;
-        y0 = (cOsd::OsdHeight() - OSDheight) / 2;
-        dsyslog("OSD-Teletext: OSD area calculated by percent  values: x0=%d y0=%d width=%d (%d%% of %d) height=%d (%d%% of %d)", x0, y0, OSDwidth, ttSetup.OSDwidthPct, cOsd::OsdWidth(), OSDheight, ttSetup.OSDheightPct, cOsd::OsdHeight());
-    } else {
-        x0=Setup.OSDLeft+(Setup.OSDWidth-ttSetup.OSDwidth)*ttSetup.OSDHAlign/100;
-        y0=Setup.OSDTop +(Setup.OSDHeight-ttSetup.OSDheight)*ttSetup.OSDVAlign/100;
-        OSDwidth =ttSetup.OSDwidth;
-        OSDheight=ttSetup.OSDheight;
-        dsyslog("OSD-Teletext: OSD area calculated by absolute values: x0=%d y0=%d width=%d height=%d", x0, y0, OSDwidth, OSDheight);
-    }
+    // calculate left/top offset for centering
+    x0 = cOsd::OsdLeft() + (cOsd::OsdWidth() - OSDwidth) / 2;
+    y0 = cOsd::OsdTop() + (cOsd::OsdHeight() - OSDheight) / 2;
+    dsyslog("OSD-Teletext: OSD area calculated by percent values: OsdLeft=%d OsdTop=%d OsdWidth=%d OsdHeight=%d OSDwidthPct=%d%% OSDheightPct=%d%% => x0=%d y0=%d width=%d height=%d", cOsd::OsdLeft(), cOsd::OsdTop(), cOsd::OsdWidth(), cOsd::OsdHeight(), ttSetup.OSDwidthPct, ttSetup.OSDheightPct, x0, y0, OSDwidth, OSDheight);
 
     switch (NewMode) {
-    case Display::Full:
+      case Display::Full:
         // Need to re-initialize *display:
         Delete();
         // Try 32BPP display first:
         display=new cDisplay32BPP(x0,y0,OSDwidth,OSDheight);
         break;
-    case Display::HalfUpper:
+      case Display::HalfUpper:
         // Shortcut to switch from HalfUpper to HalfLower:
         if (mode==Display::HalfLower) {
             // keep instance.
@@ -84,7 +76,7 @@ void Display::SetMode(Display::Mode NewMode) {
         Delete();
         display=new cDisplay32BPPHalf(x0,y0,OSDwidth,OSDheight,true);
         break;
-    case Display::HalfLower:
+      case Display::HalfLower:
         // Shortcut to switch from HalfUpper to HalfLower:
         if (mode==Display::HalfUpper) {
             // keep instance.

--- a/display.c
+++ b/display.c
@@ -32,15 +32,26 @@ void Display::SetMode(Display::Mode NewMode) {
     // No change, nothing to do
 
     // OSD origin, centered on VDR OSD
+#ifdef OSDSIZEPCT
+    int OSDheight = (cOsd::OsdHeight() * ttSetup.OSDheightPct) / 100;
+    int OSDwidth = (cOsd::OsdWidth() * ttSetup.OSDwidthPct) / 100;
+    int x0 = (cOsd::OsdWidth() - OSDwidth) / 2;
+    int y0 = (cOsd::OsdHeight() - OSDheight) / 2;
+#else
     int x0=Setup.OSDLeft+(Setup.OSDWidth-ttSetup.OSDwidth)*ttSetup.OSDHAlign/100;
     int y0=Setup.OSDTop +(Setup.OSDHeight-ttSetup.OSDheight)*ttSetup.OSDVAlign/100;
+#endif
 
     switch (NewMode) {
     case Display::Full:
         // Need to re-initialize *display:
         Delete();
         // Try 32BPP display first:
+#ifdef OSDSIZEPCT
+        display=new cDisplay32BPP(x0,y0,OSDwidth,OSDheight);
+#else
         display=new cDisplay32BPP(x0,y0,ttSetup.OSDwidth,ttSetup.OSDheight);
+#endif
         break;
     case Display::HalfUpper:
         // Shortcut to switch from HalfUpper to HalfLower:
@@ -51,7 +62,11 @@ void Display::SetMode(Display::Mode NewMode) {
         }
         // Need to re-initialize *display:
         Delete();
+#ifdef OSDSIZEPCT
+        display=new cDisplay32BPPHalf(x0,y0,OSDwidth,OSDheight,true);
+#else
         display=new cDisplay32BPPHalf(x0,y0,ttSetup.OSDwidth,ttSetup.OSDheight,true);
+#endif
         break;
     case Display::HalfLower:
         // Shortcut to switch from HalfUpper to HalfLower:
@@ -62,7 +77,11 @@ void Display::SetMode(Display::Mode NewMode) {
         }
         // Need to re-initialize *display:
         Delete();
+#ifdef OSDSIZEPCT
+        display=new cDisplay32BPPHalf(x0,y0,OSDwidth,OSDheight,false);
+#else
         display=new cDisplay32BPPHalf(x0,y0,ttSetup.OSDwidth,ttSetup.OSDheight,false);
+#endif
         break;
     }
     mode=NewMode;

--- a/displaybase.c
+++ b/displaybase.c
@@ -422,7 +422,11 @@ void cDisplay::DrawChar(int x, int y, cTeletextChar c) {
             cBitmap charBm(w, h, 24);
             charBm.DrawRectangle(0, 0, w, h, bg);
 //            charBm.DrawText(0, 0, buf, fg, bg, font);
+#ifdef OSDSIZEPCT
+            charBm.DrawText(0, (ttSetup.txtVoffset * ttSetup.OSDheightPct) / 100, buf, fg, 0, font);
+#else
             charBm.DrawText(0, ttSetup.txtVoffset, buf, fg, 0, font);
+#endif
             osd->DrawBitmap(vx, vy, charBm);
 #endif
         }

--- a/displaybase.c
+++ b/displaybase.c
@@ -422,7 +422,8 @@ void cDisplay::DrawChar(int x, int y, cTeletextChar c) {
             cBitmap charBm(w, h, 24);
             charBm.DrawRectangle(0, 0, w, h, bg);
 //            charBm.DrawText(0, 0, buf, fg, bg, font);
-            charBm.DrawText(0, (ttSetup.txtVoffset * osd->Height()) / cOsd::OsdHeight(), buf, fg, 0, font);
+            charBm.DrawText(0, (ttSetup.txtVoffset * outputHeight) / cOsd::OsdHeight(), buf, fg, 0, font);
+            // dsyslog("vertical offset: txtVoffset=%d outputHeight=%d cOsd::OsdHeight()=%d shift=%d", ttSetup.txtVoffset, outputHeight, cOsd::OsdHeight(), (ttSetup.txtVoffset * osd->Height()) / cOsd::OsdHeight());
             osd->DrawBitmap(vx, vy, charBm);
 #endif
         }
@@ -585,3 +586,5 @@ void cDisplay::ClearMessage() {
 
     Flush();
 }
+
+// vim: ts=4 sw=4 et

--- a/displaybase.c
+++ b/displaybase.c
@@ -311,6 +311,11 @@ void cDisplay::DrawChar(int x, int y, cTeletextChar c) {
     enumTeletextColor ttfg=c.GetFGColor();
     enumTeletextColor ttbg=c.GetBGColor();
 
+    static int cache_txtVoffset   = -1;
+    static int cache_outputHeight = -1;
+    static int cache_OsdHeight    = -1;
+    static int cache_Vshift = 0;
+
     if (c.GetBoxedOut()) {
         ttbg=ttcTransparent;
         ttfg=ttcTransparent;
@@ -422,8 +427,18 @@ void cDisplay::DrawChar(int x, int y, cTeletextChar c) {
             cBitmap charBm(w, h, 24);
             charBm.DrawRectangle(0, 0, w, h, bg);
 //            charBm.DrawText(0, 0, buf, fg, bg, font);
-            charBm.DrawText(0, (ttSetup.txtVoffset * outputHeight) / cOsd::OsdHeight(), buf, fg, 0, font);
-            // dsyslog("vertical offset: txtVoffset=%d outputHeight=%d cOsd::OsdHeight()=%d shift=%d", ttSetup.txtVoffset, outputHeight, cOsd::OsdHeight(), (ttSetup.txtVoffset * osd->Height()) / cOsd::OsdHeight());
+            if (
+                 (cache_txtVoffset   < 0) || (cache_txtVoffset   != ttSetup.txtVoffset)
+              || (cache_outputHeight < 0) || (cache_outputHeight != outputHeight      )
+              || (cache_OsdHeight    < 0) || (cache_OsdHeight    != cOsd::OsdHeight() )
+            ) {
+                cache_txtVoffset   = ttSetup.txtVoffset;
+                cache_outputHeight = outputHeight;
+                cache_OsdHeight    = cOsd::OsdHeight();
+                cache_Vshift       = (cache_txtVoffset * cache_outputHeight) / cache_OsdHeight;
+                dsyslog("OSD-Teletext: DrawText vertical shift cache updated: txtVoffset=%d outputHeight=%d OsdHeight=%d => Vshift=%d", cache_txtVoffset, cache_outputHeight, cache_OsdHeight, cache_Vshift);
+            };
+            charBm.DrawText(0, cache_Vshift, buf, fg, 0, font);
             osd->DrawBitmap(vx, vy, charBm);
 #endif
         }

--- a/displaybase.c
+++ b/displaybase.c
@@ -422,11 +422,7 @@ void cDisplay::DrawChar(int x, int y, cTeletextChar c) {
             cBitmap charBm(w, h, 24);
             charBm.DrawRectangle(0, 0, w, h, bg);
 //            charBm.DrawText(0, 0, buf, fg, bg, font);
-#ifdef OSDSIZEPCT
-            charBm.DrawText(0, (ttSetup.txtVoffset * ttSetup.OSDheightPct) / 100, buf, fg, 0, font);
-#else
-            charBm.DrawText(0, ttSetup.txtVoffset, buf, fg, 0, font);
-#endif
+            charBm.DrawText(0, (ttSetup.txtVoffset * osd->Height()) / cOsd::OsdHeight(), buf, fg, 0, font);
             osd->DrawBitmap(vx, vy, charBm);
 #endif
         }

--- a/menu.c
+++ b/menu.c
@@ -647,9 +647,7 @@ TeletextSetup::TeletextSetup()
   : configuredClrBackground(clrGray50), showClock(true),
     suspendReceiving(false), autoUpdatePage(true),
     //OSDHeight+width default values given in Start()
-    OSDsizePctMode(false),
     OSDheightPct(100), OSDwidthPct(100),
-    OSDHAlign(50), OSDVAlign(50),
     //use the value set for VDR's min user inactivity.
     //Initially this value could be changed via the plugin's setup, but I removed that
     //because there is no advantage, but a possible problem when VDR's value is change

--- a/menu.c
+++ b/menu.c
@@ -647,11 +647,9 @@ TeletextSetup::TeletextSetup()
   : configuredClrBackground(clrGray50), showClock(true),
     suspendReceiving(false), autoUpdatePage(true),
     //OSDHeight+width default values given in Start()
-#ifdef OSDSIZEPCT
+    OSDsizePctMode(false),
     OSDheightPct(100), OSDwidthPct(100),
-#else
     OSDHAlign(50), OSDVAlign(50),
-#endif
     //use the value set for VDR's min user inactivity.
     //Initially this value could be changed via the plugin's setup, but I removed that
     //because there is no advantage, but a possible problem when VDR's value is change

--- a/menu.c
+++ b/menu.c
@@ -647,7 +647,11 @@ TeletextSetup::TeletextSetup()
   : configuredClrBackground(clrGray50), showClock(true),
     suspendReceiving(false), autoUpdatePage(true),
     //OSDHeight+width default values given in Start()
+#ifdef OSDSIZEPCT
+    OSDheightPct(100), OSDwidthPct(100),
+#else
     OSDHAlign(50), OSDVAlign(50),
+#endif
     //use the value set for VDR's min user inactivity.
     //Initially this value could be changed via the plugin's setup, but I removed that
     //because there is no advantage, but a possible problem when VDR's value is change

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -30,7 +30,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "0.9.9.1";
+static const char *VERSION        = "0.9.9.2";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 
@@ -189,13 +189,10 @@ bool cPluginTeletextosd::Start(void)
    initTexts();
    if (startReceiver)
       txtStatus=new cTxtStatus(storeTopText, storage);
-#ifdef OSDSIZEPCT
-   if (ttSetup.OSDheightPct<20)  ttSetup.OSDheightPct=20;
-   if (ttSetup.OSDwidthPct<20)   ttSetup.OSDwidthPct=20;
-#else
+   if (ttSetup.OSDheightPct<10)  ttSetup.OSDheightPct=10;
+   if (ttSetup.OSDwidthPct<10)   ttSetup.OSDwidthPct=10;
    if (ttSetup.OSDheight<=100)  ttSetup.OSDheight=Setup.OSDHeight;
    if (ttSetup.OSDwidth<=100)   ttSetup.OSDwidth=Setup.OSDWidth;
-#endif
 
    return true;
 }
@@ -273,15 +270,13 @@ bool cPluginTeletextosd::SetupParse(const char *Name, const char *Value)
      //currently not used
   else if (!strcasecmp(Name, "suspendReceiving")) ttSetup.suspendReceiving=atoi(Value);
   else if (!strcasecmp(Name, "autoUpdatePage")) ttSetup.autoUpdatePage=atoi(Value);
-#ifdef OSDSIZEPCT
+  else if (!strcasecmp(Name, "OSDsizePctMode")) ttSetup.OSDsizePctMode=atoi(Value);
   else if (!strcasecmp(Name, "OSDheightPct")) ttSetup.OSDheightPct=atoi(Value);
   else if (!strcasecmp(Name, "OSDwidthPct")) ttSetup.OSDwidthPct=atoi(Value);
-#else
   else if (!strcasecmp(Name, "OSDheight")) ttSetup.OSDheight=atoi(Value);
   else if (!strcasecmp(Name, "OSDwidth")) ttSetup.OSDwidth=atoi(Value);
   else if (!strcasecmp(Name, "OSDHAlign")) ttSetup.OSDHAlign=atoi(Value);
   else if (!strcasecmp(Name, "OSDVAlign")) ttSetup.OSDVAlign=atoi(Value);
-#endif
   else if (!strcasecmp(Name, "inactivityTimeout")) /*ttSetup.inactivityTimeout=atoi(Value)*/;
   else if (!strcasecmp(Name, "HideMainMenu")) ttSetup.HideMainMenu=atoi(Value);
   else if (!strcasecmp(Name, "txtFontName")) ttSetup.txtFontName=strdup(Value);
@@ -325,15 +320,13 @@ void cTeletextSetupPage::Store(void) {
    ttSetup.showClock=temp.showClock;
    ttSetup.suspendReceiving=temp.suspendReceiving;
    ttSetup.autoUpdatePage=temp.autoUpdatePage;
-#ifdef OSDSIZEPCT
+   ttSetup.OSDsizePctMode=temp.OSDsizePctMode;
    ttSetup.OSDheightPct=temp.OSDheightPct;
    ttSetup.OSDwidthPct=temp.OSDwidthPct;
-#else
    ttSetup.OSDheight=temp.OSDheight;
    ttSetup.OSDwidth=temp.OSDwidth;
    ttSetup.OSDHAlign=temp.OSDHAlign;
    ttSetup.OSDVAlign=temp.OSDVAlign;
-#endif
    ttSetup.HideMainMenu=temp.HideMainMenu;
    ttSetup.txtFontName=temp.txtFontNames[temp.txtFontIndex];
    ttSetup.txtG0Block=temp.txtG0Block;
@@ -350,15 +343,13 @@ void cTeletextSetupPage::Store(void) {
       //currently not used
    //SetupStore("suspendReceiving", ttSetup.suspendReceiving);
    SetupStore("autoUpdatePage", ttSetup.autoUpdatePage);
-#ifdef OSDSIZEPCT
+   SetupStore("OSDsizePctMode", ttSetup.OSDsizePctMode);
    SetupStore("OSDheightPct", ttSetup.OSDheightPct);
    SetupStore("OSDwidthPct", ttSetup.OSDwidthPct);
-#else
    SetupStore("OSDheight", ttSetup.OSDheight);
    SetupStore("OSDwidth", ttSetup.OSDwidth);
    SetupStore("OSDHAlign", ttSetup.OSDHAlign);
    SetupStore("OSDVAlign", ttSetup.OSDVAlign);
-#endif
    SetupStore("HideMainMenu", ttSetup.HideMainMenu);
    SetupStore("txtFontName", ttSetup.txtFontName);
    SetupStore("txtG0Block", ttSetup.txtG0Block);
@@ -399,15 +390,13 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
    temp.showClock=ttSetup.showClock;
    temp.suspendReceiving=ttSetup.suspendReceiving;
    temp.autoUpdatePage=ttSetup.autoUpdatePage;
-#ifdef OSDSIZEPCT
+   temp.OSDsizePctMode=ttSetup.OSDsizePctMode;
    temp.OSDheightPct=ttSetup.OSDheightPct;
    temp.OSDwidthPct=ttSetup.OSDwidthPct;
-#else
    temp.OSDheight=ttSetup.OSDheight;
    temp.OSDwidth=ttSetup.OSDwidth;
    temp.OSDHAlign=ttSetup.OSDHAlign;
    temp.OSDVAlign=ttSetup.OSDVAlign;
-#endif
    temp.HideMainMenu=ttSetup.HideMainMenu;
    temp.txtFontName=ttSetup.txtFontName;
    temp.txtG0Block=ttSetup.txtG0Block;
@@ -430,15 +419,16 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
 
    Add(new cMenuEditBoolItem(tr("Auto-update pages"), &temp.autoUpdatePage ));
 
-#ifdef OSDSIZEPCT
-   Add(new cMenuEditIntItem(tr("OSD height percent"), &temp.OSDheightPct, 20, 100));
-   Add(new cMenuEditIntItem(tr("OSD width percent"), &temp.OSDwidthPct, 20, 100));
-#else
-   Add(new cMenuEditIntItem(tr("OSD height"), &temp.OSDheight, 250, MAXOSDHEIGHT));
-   Add(new cMenuEditIntItem(tr("OSD width"), &temp.OSDwidth, 320, MAXOSDWIDTH));
-   Add(new cMenuEditIntItem(tr("OSD horizontal align"), &temp.OSDHAlign, 0, 100));
-   Add(new cMenuEditIntItem(tr("OSD vertical align"), &temp.OSDVAlign, 0, 100));
-#endif
+   Add(new cMenuEditBoolItem(tr("OSD % size mode"), &temp.OSDsizePctMode));
+//   if (temp.OSDsizePctMode == true) { // TODO: toggle menu depending of mode
+      Add(new cMenuEditIntItem(tr("OSD % height"), &temp.OSDheightPct, 10, 100));
+      Add(new cMenuEditIntItem(tr("OSD % width"), &temp.OSDwidthPct, 10, 100));
+//   } else {
+      Add(new cMenuEditIntItem(tr("OSD height"), &temp.OSDheight, 250, MAXOSDHEIGHT));
+      Add(new cMenuEditIntItem(tr("OSD width"), &temp.OSDwidth, 320, MAXOSDWIDTH));
+      Add(new cMenuEditIntItem(tr("OSD horizontal align"), &temp.OSDHAlign, 0, 100));
+      Add(new cMenuEditIntItem(tr("OSD vertical align"), &temp.OSDVAlign, 0, 100));
+//   }
    Add(new cMenuEditBoolItem(tr("Hide mainmenu entry"), &temp.HideMainMenu));
    Add(new cMenuEditStraItem(tr("Text Font"), &temp.txtFontIndex, temp.txtFontNames.Size(), &temp.txtFontNames[0]));
    Add(new cMenuEditStraItem(tr("G0 code block"), &temp.txtG0Block, NUMELEMENTS(temp.txtBlock), temp.txtBlock));
@@ -511,3 +501,5 @@ void ActionEdit::Init(cTeletextSetupPage* s, int num, cMenuEditIntItem  *p, cMen
 
 
 VDRPLUGINCREATOR(cPluginTeletextosd); // Don't touch this!
+
+// vim: ts=3 sw=3 et

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -420,15 +420,15 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
    Add(new cMenuEditBoolItem(tr("Auto-update pages"), &temp.autoUpdatePage ));
 
    Add(new cMenuEditBoolItem(tr("OSD % size mode"), &temp.OSDsizePctMode));
-//   if (temp.OSDsizePctMode == true) { // TODO: toggle menu depending of mode
+   if (temp.OSDsizePctMode == true) { // TODO: toggle menu depending of mode
       Add(new cMenuEditIntItem(tr("OSD % height"), &temp.OSDheightPct, 10, 100));
       Add(new cMenuEditIntItem(tr("OSD % width"), &temp.OSDwidthPct, 10, 100));
-//   } else {
+   } else {
       Add(new cMenuEditIntItem(tr("OSD height"), &temp.OSDheight, 250, MAXOSDHEIGHT));
       Add(new cMenuEditIntItem(tr("OSD width"), &temp.OSDwidth, 320, MAXOSDWIDTH));
       Add(new cMenuEditIntItem(tr("OSD horizontal align"), &temp.OSDHAlign, 0, 100));
       Add(new cMenuEditIntItem(tr("OSD vertical align"), &temp.OSDVAlign, 0, 100));
-//   }
+   };
    Add(new cMenuEditBoolItem(tr("Hide mainmenu entry"), &temp.HideMainMenu));
    Add(new cMenuEditStraItem(tr("Text Font"), &temp.txtFontIndex, temp.txtFontNames.Size(), &temp.txtFontNames[0]));
    Add(new cMenuEditStraItem(tr("G0 code block"), &temp.txtG0Block, NUMELEMENTS(temp.txtBlock), temp.txtBlock));

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -30,7 +30,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "0.9.9";
+static const char *VERSION        = "0.9.9.1";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 
@@ -189,8 +189,13 @@ bool cPluginTeletextosd::Start(void)
    initTexts();
    if (startReceiver)
       txtStatus=new cTxtStatus(storeTopText, storage);
+#ifdef OSDSIZEPCT
+   if (ttSetup.OSDheightPct<20)  ttSetup.OSDheightPct=20;
+   if (ttSetup.OSDwidthPct<20)   ttSetup.OSDwidthPct=20;
+#else
    if (ttSetup.OSDheight<=100)  ttSetup.OSDheight=Setup.OSDHeight;
    if (ttSetup.OSDwidth<=100)   ttSetup.OSDwidth=Setup.OSDWidth;
+#endif
 
    return true;
 }
@@ -268,10 +273,15 @@ bool cPluginTeletextosd::SetupParse(const char *Name, const char *Value)
      //currently not used
   else if (!strcasecmp(Name, "suspendReceiving")) ttSetup.suspendReceiving=atoi(Value);
   else if (!strcasecmp(Name, "autoUpdatePage")) ttSetup.autoUpdatePage=atoi(Value);
+#ifdef OSDSIZEPCT
+  else if (!strcasecmp(Name, "OSDheightPct")) ttSetup.OSDheightPct=atoi(Value);
+  else if (!strcasecmp(Name, "OSDwidthPct")) ttSetup.OSDwidthPct=atoi(Value);
+#else
   else if (!strcasecmp(Name, "OSDheight")) ttSetup.OSDheight=atoi(Value);
   else if (!strcasecmp(Name, "OSDwidth")) ttSetup.OSDwidth=atoi(Value);
   else if (!strcasecmp(Name, "OSDHAlign")) ttSetup.OSDHAlign=atoi(Value);
   else if (!strcasecmp(Name, "OSDVAlign")) ttSetup.OSDVAlign=atoi(Value);
+#endif
   else if (!strcasecmp(Name, "inactivityTimeout")) /*ttSetup.inactivityTimeout=atoi(Value)*/;
   else if (!strcasecmp(Name, "HideMainMenu")) ttSetup.HideMainMenu=atoi(Value);
   else if (!strcasecmp(Name, "txtFontName")) ttSetup.txtFontName=strdup(Value);
@@ -315,10 +325,15 @@ void cTeletextSetupPage::Store(void) {
    ttSetup.showClock=temp.showClock;
    ttSetup.suspendReceiving=temp.suspendReceiving;
    ttSetup.autoUpdatePage=temp.autoUpdatePage;
+#ifdef OSDSIZEPCT
+   ttSetup.OSDheightPct=temp.OSDheightPct;
+   ttSetup.OSDwidthPct=temp.OSDwidthPct;
+#else
    ttSetup.OSDheight=temp.OSDheight;
    ttSetup.OSDwidth=temp.OSDwidth;
    ttSetup.OSDHAlign=temp.OSDHAlign;
    ttSetup.OSDVAlign=temp.OSDVAlign;
+#endif
    ttSetup.HideMainMenu=temp.HideMainMenu;
    ttSetup.txtFontName=temp.txtFontNames[temp.txtFontIndex];
    ttSetup.txtG0Block=temp.txtG0Block;
@@ -335,10 +350,15 @@ void cTeletextSetupPage::Store(void) {
       //currently not used
    //SetupStore("suspendReceiving", ttSetup.suspendReceiving);
    SetupStore("autoUpdatePage", ttSetup.autoUpdatePage);
+#ifdef OSDSIZEPCT
+   SetupStore("OSDheightPct", ttSetup.OSDheightPct);
+   SetupStore("OSDwidthPct", ttSetup.OSDwidthPct);
+#else
    SetupStore("OSDheight", ttSetup.OSDheight);
    SetupStore("OSDwidth", ttSetup.OSDwidth);
    SetupStore("OSDHAlign", ttSetup.OSDHAlign);
    SetupStore("OSDVAlign", ttSetup.OSDVAlign);
+#endif
    SetupStore("HideMainMenu", ttSetup.HideMainMenu);
    SetupStore("txtFontName", ttSetup.txtFontName);
    SetupStore("txtG0Block", ttSetup.txtG0Block);
@@ -379,10 +399,15 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
    temp.showClock=ttSetup.showClock;
    temp.suspendReceiving=ttSetup.suspendReceiving;
    temp.autoUpdatePage=ttSetup.autoUpdatePage;
+#ifdef OSDSIZEPCT
+   temp.OSDheightPct=ttSetup.OSDheightPct;
+   temp.OSDwidthPct=ttSetup.OSDwidthPct;
+#else
    temp.OSDheight=ttSetup.OSDheight;
    temp.OSDwidth=ttSetup.OSDwidth;
    temp.OSDHAlign=ttSetup.OSDHAlign;
    temp.OSDVAlign=ttSetup.OSDVAlign;
+#endif
    temp.HideMainMenu=ttSetup.HideMainMenu;
    temp.txtFontName=ttSetup.txtFontName;
    temp.txtG0Block=ttSetup.txtG0Block;
@@ -405,11 +430,15 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
 
    Add(new cMenuEditBoolItem(tr("Auto-update pages"), &temp.autoUpdatePage ));
 
+#ifdef OSDSIZEPCT
+   Add(new cMenuEditIntItem(tr("OSD height percent"), &temp.OSDheightPct, 20, 100));
+   Add(new cMenuEditIntItem(tr("OSD width percent"), &temp.OSDwidthPct, 20, 100));
+#else
    Add(new cMenuEditIntItem(tr("OSD height"), &temp.OSDheight, 250, MAXOSDHEIGHT));
    Add(new cMenuEditIntItem(tr("OSD width"), &temp.OSDwidth, 320, MAXOSDWIDTH));
-
    Add(new cMenuEditIntItem(tr("OSD horizontal align"), &temp.OSDHAlign, 0, 100));
    Add(new cMenuEditIntItem(tr("OSD vertical align"), &temp.OSDVAlign, 0, 100));
+#endif
    Add(new cMenuEditBoolItem(tr("Hide mainmenu entry"), &temp.HideMainMenu));
    Add(new cMenuEditStraItem(tr("Text Font"), &temp.txtFontIndex, temp.txtFontNames.Size(), &temp.txtFontNames[0]));
    Add(new cMenuEditStraItem(tr("G0 code block"), &temp.txtG0Block, NUMELEMENTS(temp.txtBlock), temp.txtBlock));

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -420,7 +420,7 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
    Add(new cMenuEditBoolItem(tr("Auto-update pages"), &temp.autoUpdatePage ));
 
    Add(new cMenuEditBoolItem(tr("OSD % size mode"), &temp.OSDsizePctMode));
-   if (temp.OSDsizePctMode == true) { // TODO: toggle menu depending of mode
+   if (temp.OSDsizePctMode == true) { // TODO HOWTO?: get instant active, not only after closing plugin config menu
       Add(new cMenuEditIntItem(tr("OSD % height"), &temp.OSDheightPct, 10, 100));
       Add(new cMenuEditIntItem(tr("OSD % width"), &temp.OSDwidthPct, 10, 100));
    } else {

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -30,7 +30,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "0.9.9.3";
+static const char *VERSION        = "1.0.0";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -30,7 +30,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "0.9.9.2";
+static const char *VERSION        = "0.9.9.3";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 
@@ -191,8 +191,6 @@ bool cPluginTeletextosd::Start(void)
       txtStatus=new cTxtStatus(storeTopText, storage);
    if (ttSetup.OSDheightPct<10)  ttSetup.OSDheightPct=10;
    if (ttSetup.OSDwidthPct<10)   ttSetup.OSDwidthPct=10;
-   if (ttSetup.OSDheight<=100)  ttSetup.OSDheight=Setup.OSDHeight;
-   if (ttSetup.OSDwidth<=100)   ttSetup.OSDwidth=Setup.OSDWidth;
 
    return true;
 }
@@ -270,13 +268,8 @@ bool cPluginTeletextosd::SetupParse(const char *Name, const char *Value)
      //currently not used
   else if (!strcasecmp(Name, "suspendReceiving")) ttSetup.suspendReceiving=atoi(Value);
   else if (!strcasecmp(Name, "autoUpdatePage")) ttSetup.autoUpdatePage=atoi(Value);
-  else if (!strcasecmp(Name, "OSDsizePctMode")) ttSetup.OSDsizePctMode=atoi(Value);
   else if (!strcasecmp(Name, "OSDheightPct")) ttSetup.OSDheightPct=atoi(Value);
   else if (!strcasecmp(Name, "OSDwidthPct")) ttSetup.OSDwidthPct=atoi(Value);
-  else if (!strcasecmp(Name, "OSDheight")) ttSetup.OSDheight=atoi(Value);
-  else if (!strcasecmp(Name, "OSDwidth")) ttSetup.OSDwidth=atoi(Value);
-  else if (!strcasecmp(Name, "OSDHAlign")) ttSetup.OSDHAlign=atoi(Value);
-  else if (!strcasecmp(Name, "OSDVAlign")) ttSetup.OSDVAlign=atoi(Value);
   else if (!strcasecmp(Name, "inactivityTimeout")) /*ttSetup.inactivityTimeout=atoi(Value)*/;
   else if (!strcasecmp(Name, "HideMainMenu")) ttSetup.HideMainMenu=atoi(Value);
   else if (!strcasecmp(Name, "txtFontName")) ttSetup.txtFontName=strdup(Value);
@@ -320,13 +313,8 @@ void cTeletextSetupPage::Store(void) {
    ttSetup.showClock=temp.showClock;
    ttSetup.suspendReceiving=temp.suspendReceiving;
    ttSetup.autoUpdatePage=temp.autoUpdatePage;
-   ttSetup.OSDsizePctMode=temp.OSDsizePctMode;
    ttSetup.OSDheightPct=temp.OSDheightPct;
    ttSetup.OSDwidthPct=temp.OSDwidthPct;
-   ttSetup.OSDheight=temp.OSDheight;
-   ttSetup.OSDwidth=temp.OSDwidth;
-   ttSetup.OSDHAlign=temp.OSDHAlign;
-   ttSetup.OSDVAlign=temp.OSDVAlign;
    ttSetup.HideMainMenu=temp.HideMainMenu;
    ttSetup.txtFontName=temp.txtFontNames[temp.txtFontIndex];
    ttSetup.txtG0Block=temp.txtG0Block;
@@ -343,13 +331,8 @@ void cTeletextSetupPage::Store(void) {
       //currently not used
    //SetupStore("suspendReceiving", ttSetup.suspendReceiving);
    SetupStore("autoUpdatePage", ttSetup.autoUpdatePage);
-   SetupStore("OSDsizePctMode", ttSetup.OSDsizePctMode);
    SetupStore("OSDheightPct", ttSetup.OSDheightPct);
    SetupStore("OSDwidthPct", ttSetup.OSDwidthPct);
-   SetupStore("OSDheight", ttSetup.OSDheight);
-   SetupStore("OSDwidth", ttSetup.OSDwidth);
-   SetupStore("OSDHAlign", ttSetup.OSDHAlign);
-   SetupStore("OSDVAlign", ttSetup.OSDVAlign);
    SetupStore("HideMainMenu", ttSetup.HideMainMenu);
    SetupStore("txtFontName", ttSetup.txtFontName);
    SetupStore("txtG0Block", ttSetup.txtG0Block);
@@ -390,13 +373,8 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
    temp.showClock=ttSetup.showClock;
    temp.suspendReceiving=ttSetup.suspendReceiving;
    temp.autoUpdatePage=ttSetup.autoUpdatePage;
-   temp.OSDsizePctMode=ttSetup.OSDsizePctMode;
    temp.OSDheightPct=ttSetup.OSDheightPct;
    temp.OSDwidthPct=ttSetup.OSDwidthPct;
-   temp.OSDheight=ttSetup.OSDheight;
-   temp.OSDwidth=ttSetup.OSDwidth;
-   temp.OSDHAlign=ttSetup.OSDHAlign;
-   temp.OSDVAlign=ttSetup.OSDVAlign;
    temp.HideMainMenu=ttSetup.HideMainMenu;
    temp.txtFontName=ttSetup.txtFontName;
    temp.txtG0Block=ttSetup.txtG0Block;
@@ -418,17 +396,8 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
    //Add(new cMenuEditBoolItem(tr("Setup$Suspend receiving"), &temp.suspendReceiving ));
 
    Add(new cMenuEditBoolItem(tr("Auto-update pages"), &temp.autoUpdatePage ));
-
-   Add(new cMenuEditBoolItem(tr("OSD % size mode"), &temp.OSDsizePctMode));
-   if (temp.OSDsizePctMode == true) { // TODO HOWTO?: get instant active, not only after closing plugin config menu
-      Add(new cMenuEditIntItem(tr("OSD % height"), &temp.OSDheightPct, 10, 100));
-      Add(new cMenuEditIntItem(tr("OSD % width"), &temp.OSDwidthPct, 10, 100));
-   } else {
-      Add(new cMenuEditIntItem(tr("OSD height"), &temp.OSDheight, 250, MAXOSDHEIGHT));
-      Add(new cMenuEditIntItem(tr("OSD width"), &temp.OSDwidth, 320, MAXOSDWIDTH));
-      Add(new cMenuEditIntItem(tr("OSD horizontal align"), &temp.OSDHAlign, 0, 100));
-      Add(new cMenuEditIntItem(tr("OSD vertical align"), &temp.OSDVAlign, 0, 100));
-   };
+   Add(new cMenuEditIntItem(tr("OSD width (%)"), &temp.OSDwidthPct, 10, 100));
+   Add(new cMenuEditIntItem(tr("OSD height (%)"), &temp.OSDheightPct, 10, 100));
    Add(new cMenuEditBoolItem(tr("Hide mainmenu entry"), &temp.HideMainMenu));
    Add(new cMenuEditStraItem(tr("Text Font"), &temp.txtFontIndex, temp.txtFontNames.Size(), &temp.txtFontNames[0]));
    Add(new cMenuEditStraItem(tr("G0 code block"), &temp.txtG0Block, NUMELEMENTS(temp.txtBlock), temp.txtBlock));

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-01-30 08:26+0100\n"
+"POT-Creation-Date: 2021-02-21 09:02+0100\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Klaus Schmidinger <Klaus.Schmidinger@tvdr.de>\n"
 "Language-Team: German <vdr@linuxtv.org>\n"
@@ -81,6 +81,17 @@ msgstr "Uhr anzeigen"
 
 msgid "Auto-update pages"
 msgstr "Seiten aktualisieren"
+
+#, c-format
+msgid "OSD % size mode"
+msgstr "OSD % Größen-Modus"
+
+#, c-format
+msgid "OSD % height"
+msgstr "OSD % Höhe"
+
+msgid "OSD % width"
+msgstr "OSD % Breite"
 
 msgid "OSD height"
 msgstr "OSD-Höhe"

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -82,11 +82,9 @@ msgstr "Uhr anzeigen"
 msgid "Auto-update pages"
 msgstr "Seiten aktualisieren"
 
-#, c-format
 msgid "OSD % size mode"
 msgstr "OSD % Größen-Modus"
 
-#, c-format
 msgid "OSD % height"
 msgstr "OSD % Höhe"
 

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-02-21 09:02+0100\n"
+"POT-Creation-Date: 2021-02-23 07:43+0100\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Klaus Schmidinger <Klaus.Schmidinger@tvdr.de>\n"
 "Language-Team: German <vdr@linuxtv.org>\n"
@@ -82,26 +82,11 @@ msgstr "Uhr anzeigen"
 msgid "Auto-update pages"
 msgstr "Seiten aktualisieren"
 
-msgid "OSD % size mode"
-msgstr "OSD % Größen-Modus"
+msgid "OSD width (%)"
+msgstr "OSD Breite (%)"
 
-msgid "OSD % height"
-msgstr "OSD % Höhe"
-
-msgid "OSD % width"
-msgstr "OSD % Breite"
-
-msgid "OSD height"
-msgstr "OSD-Höhe"
-
-msgid "OSD width"
-msgstr "OSD-Breite"
-
-msgid "OSD horizontal align"
-msgstr "OSD horizontale Anordnung"
-
-msgid "OSD vertical align"
-msgstr "OSD vertikale Anordnung"
+msgid "OSD height (%)"
+msgstr "OSD Höhe (%)"
 
 msgid "Hide mainmenu entry"
 msgstr "Hauptmenüeintrag verstecken"
@@ -126,3 +111,26 @@ msgstr "Tastenzuweisung"
 
 msgid "  Page number"
 msgstr "  Seitenzahl"
+
+#, fuzzy, c-format
+#~ msgid "OSD % size mode"
+#~ msgstr "OSD % Größen-Modus"
+
+#, fuzzy, c-format
+#~ msgid "OSD % height"
+#~ msgstr "OSD % Höhe"
+
+#~ msgid "OSD % width"
+#~ msgstr "OSD % Breite"
+
+#~ msgid "OSD height"
+#~ msgstr "OSD-Höhe"
+
+#~ msgid "OSD width"
+#~ msgstr "OSD-Breite"
+
+#~ msgid "OSD horizontal align"
+#~ msgstr "OSD horizontale Anordnung"
+
+#~ msgid "OSD vertical align"
+#~ msgstr "OSD vertikale Anordnung"

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -111,26 +111,3 @@ msgstr "Tastenzuweisung"
 
 msgid "  Page number"
 msgstr "  Seitenzahl"
-
-#, fuzzy, c-format
-#~ msgid "OSD % size mode"
-#~ msgstr "OSD % Größen-Modus"
-
-#, fuzzy, c-format
-#~ msgid "OSD % height"
-#~ msgstr "OSD % Höhe"
-
-#~ msgid "OSD % width"
-#~ msgstr "OSD % Breite"
-
-#~ msgid "OSD height"
-#~ msgstr "OSD-Höhe"
-
-#~ msgid "OSD width"
-#~ msgstr "OSD-Breite"
-
-#~ msgid "OSD horizontal align"
-#~ msgstr "OSD horizontale Anordnung"
-
-#~ msgid "OSD vertical align"
-#~ msgstr "OSD vertikale Anordnung"

--- a/setup.h
+++ b/setup.h
@@ -40,15 +40,13 @@ public:
    int showClock;
    int suspendReceiving;
    int autoUpdatePage;
-#ifdef OSDSIZEPCT
+   int OSDsizePctMode;
    int OSDheightPct;
    int OSDwidthPct;
-#else
    int OSDheight;
    int OSDwidth;
    int OSDHAlign;
    int OSDVAlign;
-#endif
    int inactivityTimeout;
    int HideMainMenu;
    cString txtFontName;

--- a/setup.h
+++ b/setup.h
@@ -40,13 +40,8 @@ public:
    int showClock;
    int suspendReceiving;
    int autoUpdatePage;
-   int OSDsizePctMode;
    int OSDheightPct;
    int OSDwidthPct;
-   int OSDheight;
-   int OSDwidth;
-   int OSDHAlign;
-   int OSDVAlign;
    int inactivityTimeout;
    int HideMainMenu;
    cString txtFontName;

--- a/setup.h
+++ b/setup.h
@@ -40,10 +40,15 @@ public:
    int showClock;
    int suspendReceiving;
    int autoUpdatePage;
+#ifdef OSDSIZEPCT
+   int OSDheightPct;
+   int OSDwidthPct;
+#else
    int OSDheight;
    int OSDwidth;
    int OSDHAlign;
    int OSDVAlign;
+#endif
    int inactivityTimeout;
    int HideMainMenu;
    cString txtFontName;


### PR DESCRIPTION
- replace OSD sizing options by percent values and always-centric
- scale "Text Vertical Offset" according to reduced size
