### PR TITLE
Re-adding top/left OSD offset, additional fixes

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,8 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
+2021-02-25: version 1.0.3
+- [pbiering] fix 'half' mode
+
 2021-02-25: version 1.0.2
 - [pbiering] replace percent based vertical/horizontal center option by top/left (re-add dropped feature)
 

--- a/HISTORY
+++ b/HISTORY
@@ -1,7 +1,10 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
+2021-02-25: version 1.0.2
+- [pbiering] replace percent based vertical/horizontal center option by top/left (re-add dropped feature)
+
 2021-02-25: version 1.0.1
-- [pbiering] add percent based vertical/horizontal center option (re-add dropped feature)
+- [pbiering] add percent based vertical/horizontal center option
 
 2021-02-23: version 1.0.0
 - [pbiering] replace OSD sizing options by percent values and always-centric

--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,8 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
+2021-02-25: version 1.0.1
+- [pbiering] add percent based vertical/horizontal center option (re-add dropped feature)
+
 2021-02-23: version 1.0.0
 - [pbiering] replace OSD sizing options by percent values and always-centric
 - [pbiering] scale "Text Vertical Offset" according to reduced size

--- a/README
+++ b/README
@@ -79,8 +79,15 @@ Other Setup options:
                if yes.
    OSD width, OSD height: 
                Adjusts the width and height of the OSD independent from VDR's
-               settings. The valid range is 40 to 56 for the width and 12 to
-               21 for the height.
+               settings. The valid range is 10% to 100%
+   OSD left, OSD top:
+               Adjusts the left and top edge of the OSD independent from VDR's
+               settings. The valid range is 0% to 90%
+   Text Vertical Offset:
+               Adjust the vertical offset by amount of (scaled) pixels
+               The valid range is 0 to 10
+   Color Mode 4bpp:
+               Enforce 16-color mode (for some older DVB cards)
    Minimum user inactivity: 
                Sets a timeout (in minutes) for user inactivity. When this
                timespan has elapsed and the user did not press any keys, the

--- a/README
+++ b/README
@@ -85,7 +85,7 @@ Other Setup options:
                settings. The valid range is 0% to 90%
    Text Vertical Offset:
                Adjust the vertical offset by amount of (scaled) pixels
-               The valid range is 0 to 10
+               The valid range is -10 to 10 (and depending on selected font)
    Color Mode 4bpp:
                Enforce 16-color mode (for some older DVB cards)
    Minimum user inactivity: 

--- a/README.DE
+++ b/README.DE
@@ -55,7 +55,7 @@ Andere Optionen:
                bestimmt werden. Valider Bereich zwischen 0% und 90%
    Vertikaler Text Offset:
                Justage des vertikalen Offsets für Textdarstellung bei einer (skalierten) Anzahl von Pixels
-               Valider Bereich zwischen 0 und 10
+               Valider Bereich zwischen -10 und 10 (und abhängig vom ausgewählten Font)
    16-Farben-Modus:
                Benutze nur 16 Farben (4-Bit) (für ältere DVB Karten)
    Mindest Benutzer-Inaktivität:

--- a/README.DE
+++ b/README.DE
@@ -48,9 +48,16 @@ Andere Optionen:
    Automatisch aktualisieren: 
                Überprüft ständig, ob sich die Seite geändert hat und aktualisiert sie wenn nötig
    OSD-Breite, OSD-Höhe: 
-               Hier kann die Breite des OSD unabhängig von den Einstellungen für VDR
-               bestimmt werden. Für die Breite liegt die Zahl zwischen 40 und 56,
-               für die Höhe zwischen 12 und 21.
+               Hier kann die Größe des OSD unabhängig von den Einstellungen für VDR
+               bestimmt werden. Valider Bereich zwischen 10% und 100%
+   OSD Links, OSD Oben:
+               Hier kann die linke/obere Ecke des OSD unabhängig von den Einstellungen für VDR
+               bestimmt werden. Valider Bereich zwischen 0% und 90%
+   Vertikaler Text Offset:
+               Justage des vertikalen Offsets für Textdarstellung bei einer (skalierten) Anzahl von Pixels
+               Valider Bereich zwischen 0 und 10
+   16-Farben-Modus:
+               Benutze nur 16 Farben (4-Bit) (für ältere DVB Karten)
    Mindest Benutzer-Inaktivität:
                Bestimmt die Zeit (in Minuten), nach der das Plugin automatisch geschlossen wird, wenn
                der Benutzer solange keine Taste betätigt hat. Das kann durch setzen des Wertes auf 0

--- a/display.c
+++ b/display.c
@@ -54,9 +54,24 @@ void Display::SetMode(Display::Mode NewMode) {
     if ((ttSetup.OSDheightPct < 100) && ((OSDheight % vLines) > 0)) OSDheight = (OSDheight / vLines) * vLines;
 
     // calculate left/top offset for centering
-    x0 = cOsd::OsdLeft() + (cOsd::OsdWidth() - OSDwidth) / 2;
-    y0 = cOsd::OsdTop() + (cOsd::OsdHeight() - OSDheight) / 2;
-    dsyslog("OSD-Teletext: OSD area calculated by percent values: OsdLeft=%d OsdTop=%d OsdWidth=%d OsdHeight=%d OSDwidthPct=%d%% OSDheightPct=%d%% => x0=%d y0=%d width=%d height=%d", cOsd::OsdLeft(), cOsd::OsdTop(), cOsd::OsdWidth(), cOsd::OsdHeight(), ttSetup.OSDwidthPct, ttSetup.OSDheightPct, x0, y0, OSDwidth, OSDheight);
+    if (ttSetup.OSDhcentPct == 0) {
+        x0 = cOsd::OsdLeft() + (cOsd::OsdWidth() - OSDwidth) / 2;
+    } else {
+        x0 = ((cOsd::OsdWidth() - OSDwidth) / 2) + (cOsd::OsdWidth() * ttSetup.OSDhcentPct / 100);
+        if (x0 < 0) x0 = 0;
+        if (x0 >= (cOsd::OsdWidth() - OSDwidth)) x0 = (cOsd::OsdWidth() - OSDwidth) - 1;
+        x0 += cOsd::OsdLeft();
+    };
+
+    if (ttSetup.OSDvcentPct == 0) {
+        y0 = cOsd::OsdTop() + (cOsd::OsdHeight() - OSDheight) / 2;
+    } else {
+        y0 = ((cOsd::OsdHeight() - OSDheight) / 2) + (cOsd::OsdHeight() * ttSetup.OSDvcentPct / 100);
+        if (y0 < 0) y0 = 0;
+        if (y0 >= (cOsd::OsdHeight() - OSDheight)) y0 = (cOsd::OsdHeight() - OSDheight) - 1;
+        y0 += cOsd::OsdTop();
+    };
+    dsyslog("OSD-Teletext: OSD area calculated by percent values: OsdLeft=%d OsdTop=%d OsdWidth=%d OsdHeight=%d OSDwidthPct=%d%% OSDheightPct=%d%% Osdhcent=%d%% Osdvcent=%d%% => x0=%d y0=%d width=%d height=%d", cOsd::OsdLeft(), cOsd::OsdTop(), cOsd::OsdWidth(), cOsd::OsdHeight(), ttSetup.OSDwidthPct, ttSetup.OSDheightPct, ttSetup.OSDhcentPct, ttSetup.OSDvcentPct, x0, y0, OSDwidth, OSDheight);
 
     switch (NewMode) {
       case Display::Full:

--- a/display.c
+++ b/display.c
@@ -176,7 +176,7 @@ cDisplay32BPPHalf::cDisplay32BPPHalf(int x0, int y0, int width, int height, bool
 
 void cDisplay32BPPHalf::InitOSD() {
     delete osd;
-    osd = cOsdProvider::NewOsd(OsdX0, OsdY0);
+    osd = cOsdProvider::NewOsd(OsdX0, OsdY0 + Height / 2);
     if (!osd) return;
 
     int width=(Width+1)&~1; // Width has to end on byte boundary, so round up

--- a/display.c
+++ b/display.c
@@ -176,7 +176,9 @@ cDisplay32BPPHalf::cDisplay32BPPHalf(int x0, int y0, int width, int height, bool
 
 void cDisplay32BPPHalf::InitOSD() {
     delete osd;
-    osd = cOsdProvider::NewOsd(OsdX0, OsdY0 + Height / 2);
+    int x0 = OsdX0;
+    int y0 = OsdY0 + Height / 2;
+    osd = cOsdProvider::NewOsd(x0, y0);
     if (!osd) return;
 
     int width=(Width+1)&~1; // Width has to end on byte boundary, so round up
@@ -195,7 +197,7 @@ void cDisplay32BPPHalf::InitOSD() {
     }
     if (osd->CanHandleAreas(Areas, sizeof(Areas) / sizeof(tArea)) != oeOk) {
         DELETENULL(osd);
-        esyslog("OSD-Teletext: can't create requested OSD 'half' area with width=%d height=%d bpp=%d", width, height, bpp);
+        esyslog("OSD-Teletext: can't create requested OSD 'half' area with x0=%d y0=%d width=%d height=%d bpp=%d", x0, y0, width, height, bpp);
         Skins.Message(mtError, "OSD-Teletext can't request OSD 'half' area, check plugin settings");
         return;
     }
@@ -226,7 +228,7 @@ void cDisplay32BPPHalf::InitOSD() {
 */
     osd->SetAreas(Areas, sizeof(Areas) / sizeof(tArea));
 
-    isyslog("OSD-Teletext: OSD 'half' area successful requested width=%d height=%d bpp=%d upper=%d", width, height, bpp, Upper);
+    isyslog("OSD-Teletext: OSD 'half' area successful requested x0=%d y0=%d width=%d height=%d bpp=%d upper=%d", x0, y0, width, height, bpp, Upper);
 
     setOutputWidth(width);
     setOutputHeight(height);

--- a/display.c
+++ b/display.c
@@ -180,15 +180,13 @@ void cDisplay32BPPHalf::InitOSD() {
 
     int width=(Width+1)&~1; // Width has to end on byte boundary, so round up
     int height=Height;
-    int x0 = 0;
-    int y0 = 0;
 
     int bpp = 32;
     if (ttSetup.colorMode4bpp == true) {
         bpp = 4;
         dsyslog("OSD-Teletext: OSD config forced to bpp=%d", bpp);
     };
-    tArea Areas[] = { { x0, y0, width - 1, height - 1, bpp } };
+    tArea Areas[] = { { 0, 0, width - 1, height - 1, bpp } };
     if (bpp == 32 && (osd->CanHandleAreas(Areas, sizeof(Areas) / sizeof(tArea)) != oeOk)) {
         bpp = 8;
         Areas[0].bpp = 8;
@@ -196,14 +194,12 @@ void cDisplay32BPPHalf::InitOSD() {
     }
     if (osd->CanHandleAreas(Areas, sizeof(Areas) / sizeof(tArea)) != oeOk) {
         DELETENULL(osd);
-        esyslog("OSD-Teletext: can't create requested OSD area with x0=%d y0=%d width=%d height=%d bpp=%d", x0, y0, width, height, bpp);
-        Skins.Message(mtError, "OSD-Teletext can't request OSD area, check plugin settings");
+        esyslog("OSD-Teletext: can't create requested OSD 'half' area with width=%d height=%d bpp=%d", width, height, bpp);
+        Skins.Message(mtError, "OSD-Teletext can't request OSD 'half' area, check plugin settings");
         return;
     }
 
     // Try full-size area first
-    isyslog("OSD-Teletext: OSD 'half' area successful requested width=%d height=%d bpp=%d upper=%d", width, height, bpp, Upper);
-
     while (osd->CanHandleAreas(Areas, sizeof(Areas) / sizeof(tArea)) != oeOk) {
         // Out of memory, so shrink
         if (Upper) {
@@ -228,6 +224,8 @@ void cDisplay32BPPHalf::InitOSD() {
     }
 
     osd->SetAreas(Areas, sizeof(Areas) / sizeof(tArea));
+
+    isyslog("OSD-Teletext: OSD 'half' area successful requested width=%d height=%d bpp=%d upper=%d", width, height, bpp, Upper);
 
     setOutputWidth(width);
     setOutputHeight(Height);

--- a/display.c
+++ b/display.c
@@ -86,23 +86,27 @@ void Display::SetMode(Display::Mode NewMode) {
         // Shortcut to switch from HalfUpper to HalfLower:
         if (mode==Display::HalfLower) {
             // keep instance.
+            ((cDisplay32BPPHalf*)display)->SetZoom(cDisplay::Zoom_Upper);
             ((cDisplay32BPPHalf*)display)->SetUpper(true);
             break;
         }
         // Need to re-initialize *display:
         Delete();
         display=new cDisplay32BPPHalf(x0,y0,OSDwidth,OSDheight,true);
+        ((cDisplay32BPPHalf*)display)->SetZoom(cDisplay::Zoom_Upper);
         break;
       case Display::HalfLower:
         // Shortcut to switch from HalfUpper to HalfLower:
         if (mode==Display::HalfUpper) {
             // keep instance.
+            ((cDisplay32BPPHalf*)display)->SetZoom(cDisplay::Zoom_Lower);
             ((cDisplay32BPPHalf*)display)->SetUpper(false);
             break;
         }
         // Need to re-initialize *display:
         Delete();
         display=new cDisplay32BPPHalf(x0,y0,OSDwidth,OSDheight,false);
+        ((cDisplay32BPPHalf*)display)->SetZoom(cDisplay::Zoom_Lower);
         break;
     }
     mode=NewMode;
@@ -153,11 +157,6 @@ cDisplay32BPP::cDisplay32BPP(int x0, int y0, int width, int height)
     setOutputWidth(width);
     setOutputHeight(Height);
 
-#if defined(APIVERSNUM) && APIVERSNUM >= 20107
-    Width = 480;
-    Height = 250;
-#endif
-
     isyslog("OSD-Teletext: OSD area successful requested with x0=%d y0=%d width=%d height=%d bpp=%d", x0, y0, width, height, bpp);
 
     InitScaler();
@@ -181,7 +180,7 @@ void cDisplay32BPPHalf::InitOSD() {
     if (!osd) return;
 
     int width=(Width+1)&~1; // Width has to end on byte boundary, so round up
-    int height=Height;
+    int height=Height / 2;
 
     int bpp = 32;
     if (ttSetup.colorMode4bpp == true) {
@@ -200,7 +199,7 @@ void cDisplay32BPPHalf::InitOSD() {
         Skins.Message(mtError, "OSD-Teletext can't request OSD 'half' area, check plugin settings");
         return;
     }
-
+/*
     // Try full-size area first
     while (osd->CanHandleAreas(Areas, sizeof(Areas) / sizeof(tArea)) != oeOk) {
         // Out of memory, so shrink
@@ -224,18 +223,13 @@ void cDisplay32BPPHalf::InitOSD() {
     } else {
         Areas[0].y1=Areas[0].y1+10;
     }
-
+*/
     osd->SetAreas(Areas, sizeof(Areas) / sizeof(tArea));
 
     isyslog("OSD-Teletext: OSD 'half' area successful requested width=%d height=%d bpp=%d upper=%d", width, height, bpp, Upper);
 
     setOutputWidth(width);
-    setOutputHeight(Height);
-
-#if defined(APIVERSNUM) && APIVERSNUM >= 20107
-    Width = 480;
-    Height = 250;
-#endif
+    setOutputHeight(height);
 
     InitScaler();
 

--- a/display.c
+++ b/display.c
@@ -71,7 +71,7 @@ void Display::SetMode(Display::Mode NewMode) {
         if (y0 >= (cOsd::OsdHeight() - OSDheight)) y0 = (cOsd::OsdHeight() - OSDheight) - 1;
         y0 += cOsd::OsdTop();
     };
-    dsyslog("OSD-Teletext: OSD area calculated by percent values: OsdLeft=%d OsdTop=%d OsdWidth=%d OsdHeight=%d OSDwidthPct=%d%% OSDheightPct=%d%% Osdhcent=%d%% Osdvcent=%d%% => x0=%d y0=%d width=%d height=%d", cOsd::OsdLeft(), cOsd::OsdTop(), cOsd::OsdWidth(), cOsd::OsdHeight(), ttSetup.OSDwidthPct, ttSetup.OSDheightPct, ttSetup.OSDhcentPct, ttSetup.OSDvcentPct, x0, y0, OSDwidth, OSDheight);
+    dsyslog("OSD-Teletext: OSD area calculated by percent values: OsdLeft=%d OsdTop=%d OsdWidth=%d OsdHeight=%d OSDwidthPct=%d%% OSDheightPct=%d%% OSDhcentPct=%d%% OSDvcentPct=%d%% => x0=%d y0=%d width=%d height=%d", cOsd::OsdLeft(), cOsd::OsdTop(), cOsd::OsdWidth(), cOsd::OsdHeight(), ttSetup.OSDwidthPct, ttSetup.OSDheightPct, ttSetup.OSDhcentPct, ttSetup.OSDvcentPct, x0, y0, OSDwidth, OSDheight);
 
     switch (NewMode) {
       case Display::Full:

--- a/displaybase.c
+++ b/displaybase.c
@@ -309,10 +309,11 @@ void cDisplay::DrawChar(int x, int y, cTeletextChar c) {
     enumTeletextColor ttfg=c.GetFGColor();
     enumTeletextColor ttbg=c.GetBGColor();
 
-    static int cache_txtVoffset   = -1;
-    static int cache_outputHeight = -1;
-    static int cache_OsdHeight    = -1;
+    static int cache_txtVoffset   = 0;
+    static int cache_outputHeight = 0;
+    static int cache_OsdHeight    = 0;
     static int cache_Vshift = 0;
+    static int cache_valid = 0;
 
     if (c.GetBoxedOut()) {
         ttbg=ttcTransparent;
@@ -431,10 +432,13 @@ void cDisplay::DrawChar(int x, int y, cTeletextChar c) {
             charBm.DrawRectangle(0, 0, w, h, bg);
 //            charBm.DrawText(0, 0, buf, fg, bg, font);
             if (
-                 (cache_txtVoffset   < 0) || (cache_txtVoffset   != ttSetup.txtVoffset)
-              || (cache_outputHeight < 0) || (cache_outputHeight != outputHeight      )
-              || (cache_OsdHeight    < 0) || (cache_OsdHeight    != cOsd::OsdHeight() )
+                 (cache_valid == 0) || (
+                 (cache_txtVoffset   != ttSetup.txtVoffset)
+              || (cache_outputHeight != outputHeight      )
+              || (cache_OsdHeight    != cOsd::OsdHeight() )
+              )
             ) {
+                cache_valid = 1;
                 cache_txtVoffset   = ttSetup.txtVoffset;
                 cache_outputHeight = outputHeight;
                 cache_OsdHeight    = cOsd::OsdHeight();

--- a/displaybase.c
+++ b/displaybase.c
@@ -329,7 +329,7 @@ void cDisplay::DrawChar(int x, int y, cTeletextChar c) {
     int tl = Utf8CharSet(t, buf);
     buf[tl] = 0;
 
-    const cFont *font;
+    const cFont *font = TXTFont; // FIXED: -Wmaybe-uninitialized
     int charset = c.GetCharset();
     int fontType = 0;
     int w = fontWidth / 2;

--- a/displaybase.c
+++ b/displaybase.c
@@ -111,9 +111,7 @@ void cDisplay::InitScaler() {
     fontWidth &= 0xfffe;
     fontHeight &= 0xfffe;
 
-
-    dsyslog("OSD-Teletext: OSD width = %d, height = %d", outputWidth, outputHeight);
-    dsyslog("OSD-Teletext: font width * 2 = %d, height = %d", fontWidth, fontHeight);
+    dsyslog("OSD-Teletext: OSD width=%d height=%d fontWidth*2=%d fontHeight=%d", outputWidth, outputHeight, fontWidth, fontHeight);
 
     int txtFontWidth = fontWidth;
     int txtFontHeight = fontHeight;

--- a/displaybase.c
+++ b/displaybase.c
@@ -111,7 +111,7 @@ void cDisplay::InitScaler() {
     fontWidth &= 0xfffe;
     fontHeight &= 0xfffe;
 
-    dsyslog("OSD-Teletext: OSD width=%d height=%d fontWidth*2=%d fontHeight=%d", outputWidth, outputHeight, fontWidth, fontHeight);
+    dsyslog("OSD-Teletext: OSD width=%d height=%d fontWidth*2=%d fontHeight=%d ScaleX=%d ScaleY=%d", outputWidth, outputHeight, fontWidth, fontHeight, ScaleX, ScaleY);
 
     int txtFontWidth = fontWidth;
     int txtFontHeight = fontHeight;
@@ -366,8 +366,13 @@ void cDisplay::DrawChar(int x, int y, cTeletextChar c) {
     }
 
     if (Zoom == Zoom_Lower) {
-        y -= 11;
+        y -= 12;
+        if (y < 0) return;
     }
+
+    if (Zoom == Zoom_Upper) {
+        if (y > 11) return;
+    };
 
     int vx = x * fontWidth / 2;
     int vy = y * fontHeight / 2;

--- a/displaybase.c
+++ b/displaybase.c
@@ -28,7 +28,7 @@ cDisplay::cDisplay(int width, int height)
       Boxed(false), Width(width), Height(height), Background(clrGray50),
       osd(NULL), outputWidth(0), outputScaleX(1.0),
       outputHeight(0), outputScaleY(1.0),
-      ScaleX(1), ScaleY(1), OffsetX(0), OffsetY(0),
+      /* ScaleX(1), ScaleY(1), */ OffsetX(0), OffsetY(0),
       MessageFont(cFont::GetFont(fontSml)), MessageX(0), MessageY(0),
       MessageW(0), MessageH(0),
       TXTFont(0), TXTDblWFont(0), TXTDblHFont(0), TXTDblHWFont(0)
@@ -83,7 +83,7 @@ void cDisplay::InitScaler() {
     outputScaleY = (double)outputHeight/250.0;
 
     int height=Height-6;
-    int width=Width-6;
+    // int width=Width-6; // FIXED: no longer used
     OffsetX=3;
     OffsetY=3;
 
@@ -98,8 +98,8 @@ void cDisplay::InitScaler() {
     default:;
     }
 
-    ScaleX=(480<<16)/width;
-    ScaleY=(250<<16)/height;
+    // ScaleX=(480<<16)/width;  // FIXED: no longer used
+    // ScaleY=(250<<16)/height; // FIXED: no longer used
 
     fontWidth = (outputWidth * 2 / 40) & 0xfffe;
     if (Zoom == Zoom_Off) {
@@ -111,7 +111,7 @@ void cDisplay::InitScaler() {
     fontWidth &= 0xfffe;
     fontHeight &= 0xfffe;
 
-    dsyslog("OSD-Teletext: OSD width=%d height=%d fontWidth*2=%d fontHeight=%d ScaleX=%d ScaleY=%d", outputWidth, outputHeight, fontWidth, fontHeight, ScaleX, ScaleY);
+    dsyslog("OSD-Teletext: OSD width=%d height=%d fontWidth*2=%d fontHeight=%d", outputWidth, outputHeight, fontWidth, fontHeight);
 
     int txtFontWidth = fontWidth;
     int txtFontHeight = fontHeight;

--- a/displaybase.h
+++ b/displaybase.h
@@ -65,7 +65,7 @@ protected:
     double outputScaleY;
     // for 32bpp true color, If creation fails, may be NULL
 
-    int ScaleX,ScaleY;
+    // int ScaleX,ScaleY; // FIXED: no longer used
     int OffsetX,OffsetY;
     // Virtual coordinate system, see InitScaler
 
@@ -232,6 +232,7 @@ inline void cDisplay::cBox::SetToCharacter(int x, int y) {
     YMax=YMin+(10<<16)-1;
 }
 
+/*
 inline void cDisplay::cVirtualCoordinate::VirtualToPixel(cDisplay *Display, int x, int y) {
     // Map virtual coordinate to OSD pixel
     OsdX=x/Display->ScaleX+Display->OffsetX;
@@ -252,5 +253,6 @@ inline void cDisplay::cVirtualCoordinate::IncPixelY(cDisplay *Display) {
     OsdY++;
     VirtY+=Display->ScaleY;
 }
+*/
 
 #endif

--- a/menu.c
+++ b/menu.c
@@ -648,7 +648,7 @@ TeletextSetup::TeletextSetup()
     suspendReceiving(false), autoUpdatePage(true),
     //OSDHeight+width default values given in Start()
     OSDheightPct(100), OSDwidthPct(100),
-    OSDvcentPct(0), OSDhcentPct(0),
+    OSDtopPct(0), OSDleftPct(0),
     //use the value set for VDR's min user inactivity.
     //Initially this value could be changed via the plugin's setup, but I removed that
     //because there is no advantage, but a possible problem when VDR's value is change

--- a/menu.c
+++ b/menu.c
@@ -648,6 +648,7 @@ TeletextSetup::TeletextSetup()
     suspendReceiving(false), autoUpdatePage(true),
     //OSDHeight+width default values given in Start()
     OSDheightPct(100), OSDwidthPct(100),
+    OSDvcentPct(0), OSDhcentPct(0),
     //use the value set for VDR's min user inactivity.
     //Initially this value could be changed via the plugin's setup, but I removed that
     //because there is no advantage, but a possible problem when VDR's value is change

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -417,7 +417,7 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
    Add(new cMenuEditStraItem(tr("G0 code block"), &temp.txtG0Block, NUMELEMENTS(temp.txtBlock), temp.txtBlock));
    Add(new cMenuEditStraItem(tr("G2 code block"), &temp.txtG2Block, NUMELEMENTS(temp.txtBlock), temp.txtBlock));
    Add(new cMenuEditIntItem(tr("Text Vertical Offset"), &temp.txtVoffset, 0, 10));
-   Add(new cMenuEditBoolItem(tr("Color Mode 4bpp"), &temp.colorMode4bpp));
+   Add(new cMenuEditBoolItem(tr("16-Color Mode"), &temp.colorMode4bpp));
 
    //Using same string as VDR's setup menu
    //Add(new cMenuEditIntItem(tr("Setup.Miscellaneous$Min. user inactivity (min)"), &temp.inactivityTimeout));

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -195,6 +195,7 @@ bool cPluginTeletextosd::Start(void)
    if (ttSetup.OSDleftPct > 90) ttSetup.OSDleftPct = 0; // failsafe
    if (ttSetup.OSDtopPct  <  0) ttSetup.OSDtopPct  = 0; // failsafe
    if (ttSetup.OSDleftPct <  0) ttSetup.OSDleftPct = 0; // failsafe
+   if (abs(ttSetup.txtVoffset) > 10) ttSetup.txtVoffset = 0; // failsafe
 
    return true;
 }
@@ -416,7 +417,7 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
    Add(new cMenuEditStraItem(tr("Text Font"), &temp.txtFontIndex, temp.txtFontNames.Size(), &temp.txtFontNames[0]));
    Add(new cMenuEditStraItem(tr("G0 code block"), &temp.txtG0Block, NUMELEMENTS(temp.txtBlock), temp.txtBlock));
    Add(new cMenuEditStraItem(tr("G2 code block"), &temp.txtG2Block, NUMELEMENTS(temp.txtBlock), temp.txtBlock));
-   Add(new cMenuEditIntItem(tr("Text Vertical Offset"), &temp.txtVoffset, 0, 10));
+   Add(new cMenuEditIntItem(tr("Text Vertical Offset"), &temp.txtVoffset, -10, 10));
    Add(new cMenuEditBoolItem(tr("16-Color Mode"), &temp.colorMode4bpp));
 
    //Using same string as VDR's setup menu

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -191,6 +191,8 @@ bool cPluginTeletextosd::Start(void)
       txtStatus=new cTxtStatus(storeTopText, storage);
    if (ttSetup.OSDheightPct<10)  ttSetup.OSDheightPct=10;
    if (ttSetup.OSDwidthPct<10)   ttSetup.OSDwidthPct=10;
+   if (abs(ttSetup.OSDvcentPct)>50) ttSetup.OSDvcentPct=0; // failsafe
+   if (abs(ttSetup.OSDhcentPct)>50) ttSetup.OSDhcentPct=0; // failsafe
 
    return true;
 }
@@ -270,6 +272,8 @@ bool cPluginTeletextosd::SetupParse(const char *Name, const char *Value)
   else if (!strcasecmp(Name, "autoUpdatePage")) ttSetup.autoUpdatePage=atoi(Value);
   else if (!strcasecmp(Name, "OSDheightPct")) ttSetup.OSDheightPct=atoi(Value);
   else if (!strcasecmp(Name, "OSDwidthPct")) ttSetup.OSDwidthPct=atoi(Value);
+  else if (!strcasecmp(Name, "OSDvcentPct")) ttSetup.OSDvcentPct=atoi(Value);
+  else if (!strcasecmp(Name, "OSDhcentPct")) ttSetup.OSDhcentPct=atoi(Value);
   else if (!strcasecmp(Name, "inactivityTimeout")) /*ttSetup.inactivityTimeout=atoi(Value)*/;
   else if (!strcasecmp(Name, "HideMainMenu")) ttSetup.HideMainMenu=atoi(Value);
   else if (!strcasecmp(Name, "txtFontName")) ttSetup.txtFontName=strdup(Value);
@@ -315,6 +319,8 @@ void cTeletextSetupPage::Store(void) {
    ttSetup.autoUpdatePage=temp.autoUpdatePage;
    ttSetup.OSDheightPct=temp.OSDheightPct;
    ttSetup.OSDwidthPct=temp.OSDwidthPct;
+   ttSetup.OSDvcentPct=temp.OSDvcentPct;
+   ttSetup.OSDhcentPct=temp.OSDhcentPct;
    ttSetup.HideMainMenu=temp.HideMainMenu;
    ttSetup.txtFontName=temp.txtFontNames[temp.txtFontIndex];
    ttSetup.txtG0Block=temp.txtG0Block;
@@ -333,6 +339,8 @@ void cTeletextSetupPage::Store(void) {
    SetupStore("autoUpdatePage", ttSetup.autoUpdatePage);
    SetupStore("OSDheightPct", ttSetup.OSDheightPct);
    SetupStore("OSDwidthPct", ttSetup.OSDwidthPct);
+   SetupStore("OSDvcentPct", ttSetup.OSDvcentPct);
+   SetupStore("OSDhcentPct", ttSetup.OSDhcentPct);
    SetupStore("HideMainMenu", ttSetup.HideMainMenu);
    SetupStore("txtFontName", ttSetup.txtFontName);
    SetupStore("txtG0Block", ttSetup.txtG0Block);
@@ -375,6 +383,8 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
    temp.autoUpdatePage=ttSetup.autoUpdatePage;
    temp.OSDheightPct=ttSetup.OSDheightPct;
    temp.OSDwidthPct=ttSetup.OSDwidthPct;
+   temp.OSDvcentPct=ttSetup.OSDvcentPct;
+   temp.OSDhcentPct=ttSetup.OSDhcentPct;
    temp.HideMainMenu=ttSetup.HideMainMenu;
    temp.txtFontName=ttSetup.txtFontName;
    temp.txtG0Block=ttSetup.txtG0Block;
@@ -398,6 +408,8 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
    Add(new cMenuEditBoolItem(tr("Auto-update pages"), &temp.autoUpdatePage ));
    Add(new cMenuEditIntItem(tr("OSD width (%)"), &temp.OSDwidthPct, 10, 100));
    Add(new cMenuEditIntItem(tr("OSD height (%)"), &temp.OSDheightPct, 10, 100));
+   Add(new cMenuEditIntItem(tr("OSD horizontal center (%)"), &temp.OSDhcentPct, -50, +50));
+   Add(new cMenuEditIntItem(tr("OSD vertical center (%)"), &temp.OSDvcentPct, -50, +50));
    Add(new cMenuEditBoolItem(tr("Hide mainmenu entry"), &temp.HideMainMenu));
    Add(new cMenuEditStraItem(tr("Text Font"), &temp.txtFontIndex, temp.txtFontNames.Size(), &temp.txtFontNames[0]));
    Add(new cMenuEditStraItem(tr("G0 code block"), &temp.txtG0Block, NUMELEMENTS(temp.txtBlock), temp.txtBlock));

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -30,7 +30,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "1.0.1";
+static const char *VERSION        = "1.0.2";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 
@@ -191,8 +191,10 @@ bool cPluginTeletextosd::Start(void)
       txtStatus=new cTxtStatus(storeTopText, storage);
    if (ttSetup.OSDheightPct<10)  ttSetup.OSDheightPct=10;
    if (ttSetup.OSDwidthPct<10)   ttSetup.OSDwidthPct=10;
-   if (abs(ttSetup.OSDvcentPct)>50) ttSetup.OSDvcentPct=0; // failsafe
-   if (abs(ttSetup.OSDhcentPct)>50) ttSetup.OSDhcentPct=0; // failsafe
+   if (ttSetup.OSDtopPct  > 90) ttSetup.OSDtopPct  = 0; // failsafe
+   if (ttSetup.OSDleftPct > 90) ttSetup.OSDleftPct = 0; // failsafe
+   if (ttSetup.OSDtopPct  <  0) ttSetup.OSDtopPct  = 0; // failsafe
+   if (ttSetup.OSDleftPct <  0) ttSetup.OSDleftPct = 0; // failsafe
 
    return true;
 }
@@ -272,8 +274,8 @@ bool cPluginTeletextosd::SetupParse(const char *Name, const char *Value)
   else if (!strcasecmp(Name, "autoUpdatePage")) ttSetup.autoUpdatePage=atoi(Value);
   else if (!strcasecmp(Name, "OSDheightPct")) ttSetup.OSDheightPct=atoi(Value);
   else if (!strcasecmp(Name, "OSDwidthPct")) ttSetup.OSDwidthPct=atoi(Value);
-  else if (!strcasecmp(Name, "OSDvcentPct")) ttSetup.OSDvcentPct=atoi(Value);
-  else if (!strcasecmp(Name, "OSDhcentPct")) ttSetup.OSDhcentPct=atoi(Value);
+  else if (!strcasecmp(Name, "OSDtopPct")) ttSetup.OSDtopPct=atoi(Value);
+  else if (!strcasecmp(Name, "OSDleftPct")) ttSetup.OSDleftPct=atoi(Value);
   else if (!strcasecmp(Name, "inactivityTimeout")) /*ttSetup.inactivityTimeout=atoi(Value)*/;
   else if (!strcasecmp(Name, "HideMainMenu")) ttSetup.HideMainMenu=atoi(Value);
   else if (!strcasecmp(Name, "txtFontName")) ttSetup.txtFontName=strdup(Value);
@@ -319,8 +321,8 @@ void cTeletextSetupPage::Store(void) {
    ttSetup.autoUpdatePage=temp.autoUpdatePage;
    ttSetup.OSDheightPct=temp.OSDheightPct;
    ttSetup.OSDwidthPct=temp.OSDwidthPct;
-   ttSetup.OSDvcentPct=temp.OSDvcentPct;
-   ttSetup.OSDhcentPct=temp.OSDhcentPct;
+   ttSetup.OSDtopPct=temp.OSDtopPct;
+   ttSetup.OSDleftPct=temp.OSDleftPct;
    ttSetup.HideMainMenu=temp.HideMainMenu;
    ttSetup.txtFontName=temp.txtFontNames[temp.txtFontIndex];
    ttSetup.txtG0Block=temp.txtG0Block;
@@ -339,8 +341,8 @@ void cTeletextSetupPage::Store(void) {
    SetupStore("autoUpdatePage", ttSetup.autoUpdatePage);
    SetupStore("OSDheightPct", ttSetup.OSDheightPct);
    SetupStore("OSDwidthPct", ttSetup.OSDwidthPct);
-   SetupStore("OSDvcentPct", ttSetup.OSDvcentPct);
-   SetupStore("OSDhcentPct", ttSetup.OSDhcentPct);
+   SetupStore("OSDtopPct", ttSetup.OSDtopPct);
+   SetupStore("OSDleftPct", ttSetup.OSDleftPct);
    SetupStore("HideMainMenu", ttSetup.HideMainMenu);
    SetupStore("txtFontName", ttSetup.txtFontName);
    SetupStore("txtG0Block", ttSetup.txtG0Block);
@@ -383,8 +385,8 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
    temp.autoUpdatePage=ttSetup.autoUpdatePage;
    temp.OSDheightPct=ttSetup.OSDheightPct;
    temp.OSDwidthPct=ttSetup.OSDwidthPct;
-   temp.OSDvcentPct=ttSetup.OSDvcentPct;
-   temp.OSDhcentPct=ttSetup.OSDhcentPct;
+   temp.OSDtopPct=ttSetup.OSDtopPct;
+   temp.OSDleftPct=ttSetup.OSDleftPct;
    temp.HideMainMenu=ttSetup.HideMainMenu;
    temp.txtFontName=ttSetup.txtFontName;
    temp.txtG0Block=ttSetup.txtG0Block;
@@ -406,10 +408,10 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
    //Add(new cMenuEditBoolItem(tr("Setup$Suspend receiving"), &temp.suspendReceiving ));
 
    Add(new cMenuEditBoolItem(tr("Auto-update pages"), &temp.autoUpdatePage ));
+   Add(new cMenuEditIntItem(tr("OSD left (%)"), &temp.OSDleftPct, 0, 90));
+   Add(new cMenuEditIntItem(tr("OSD top (%)"), &temp.OSDtopPct, 0, 90));
    Add(new cMenuEditIntItem(tr("OSD width (%)"), &temp.OSDwidthPct, 10, 100));
    Add(new cMenuEditIntItem(tr("OSD height (%)"), &temp.OSDheightPct, 10, 100));
-   Add(new cMenuEditIntItem(tr("OSD horizontal center (%)"), &temp.OSDhcentPct, -50, +50));
-   Add(new cMenuEditIntItem(tr("OSD vertical center (%)"), &temp.OSDvcentPct, -50, +50));
    Add(new cMenuEditBoolItem(tr("Hide mainmenu entry"), &temp.HideMainMenu));
    Add(new cMenuEditStraItem(tr("Text Font"), &temp.txtFontIndex, temp.txtFontNames.Size(), &temp.txtFontNames[0]));
    Add(new cMenuEditStraItem(tr("G0 code block"), &temp.txtG0Block, NUMELEMENTS(temp.txtBlock), temp.txtBlock));

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -30,7 +30,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "1.0.2";
+static const char *VERSION        = "1.0.3";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -30,7 +30,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "1.0.0";
+static const char *VERSION        = "1.0.1";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 

--- a/po/ca_ES.po
+++ b/po/ca_ES.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-01-27 06:22+0100\n"
+"POT-Creation-Date: 2021-02-27 06:57+0100\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Jordi Vilà <jvila@tinet.org>\n"
 "Language-Team: Catalan <vdr@linuxtv.org>\n"
@@ -84,16 +84,16 @@ msgstr "Visualitza l'hora"
 msgid "Auto-update pages"
 msgstr "Actualització pàgines automàtica"
 
-msgid "OSD height"
-msgstr "Altura OSD"
-
-msgid "OSD width"
-msgstr "Amplària OSD"
-
-msgid "OSD horizontal align"
+msgid "OSD left (%)"
 msgstr ""
 
-msgid "OSD vertical align"
+msgid "OSD top (%)"
+msgstr ""
+
+msgid "OSD width (%)"
+msgstr ""
+
+msgid "OSD height (%)"
 msgstr ""
 
 msgid "Hide mainmenu entry"
@@ -108,7 +108,10 @@ msgstr ""
 msgid "G2 code block"
 msgstr ""
 
-msgid "Color Mode 4bpp"
+msgid "Text Vertical Offset"
+msgstr ""
+
+msgid "16-Color Mode"
 msgstr ""
 
 msgid "Key bindings"
@@ -116,3 +119,9 @@ msgstr ""
 
 msgid "  Page number"
 msgstr "  Nombre de pàgina"
+
+#~ msgid "OSD height"
+#~ msgstr "Altura OSD"
+
+#~ msgid "OSD width"
+#~ msgstr "Amplària OSD"

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-02-23 07:43+0100\n"
+"POT-Creation-Date: 2021-02-25 19:26+0100\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Klaus Schmidinger <Klaus.Schmidinger@tvdr.de>\n"
 "Language-Team: German <vdr@linuxtv.org>\n"
@@ -87,6 +87,12 @@ msgstr "OSD Breite (%)"
 
 msgid "OSD height (%)"
 msgstr "OSD Höhe (%)"
+
+msgid "OSD horizontal center (%)"
+msgstr "OSD horizontale Mitte (%)"
+
+msgid "OSD vertical center (%)"
+msgstr "OSD vertikale Mitte (%)"
 
 msgid "Hide mainmenu entry"
 msgstr "Hauptmenüeintrag verstecken"

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-02-25 19:26+0100\n"
+"POT-Creation-Date: 2021-02-27 06:57+0100\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Klaus Schmidinger <Klaus.Schmidinger@tvdr.de>\n"
 "Language-Team: German <vdr@linuxtv.org>\n"
@@ -82,17 +82,17 @@ msgstr "Uhr anzeigen"
 msgid "Auto-update pages"
 msgstr "Seiten aktualisieren"
 
+msgid "OSD left (%)"
+msgstr "OSD Links (%)"
+
+msgid "OSD top (%)"
+msgstr "OSD Oben (%)"
+
 msgid "OSD width (%)"
 msgstr "OSD Breite (%)"
 
 msgid "OSD height (%)"
 msgstr "OSD Höhe (%)"
-
-msgid "OSD horizontal center (%)"
-msgstr "OSD horizontale Mitte (%)"
-
-msgid "OSD vertical center (%)"
-msgstr "OSD vertikale Mitte (%)"
 
 msgid "Hide mainmenu entry"
 msgstr "Hauptmenüeintrag verstecken"
@@ -109,8 +109,8 @@ msgstr ""
 msgid "Text Vertical Offset"
 msgstr "Text vertikaler Offset"
 
-msgid "Color Mode 4bpp"
-msgstr "Farbmodus 4bpp"
+msgid "16-Color Mode"
+msgstr "16-Farben Modus"
 
 msgid "Key bindings"
 msgstr "Tastenzuweisung"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-01-27 06:22+0100\n"
+"POT-Creation-Date: 2021-02-27 06:57+0100\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Ruben Nunez Francisco <ruben.nunez@tang-it.com>\n"
 "Language-Team: Spanish <vdr@linuxtv.org>\n"
@@ -82,16 +82,16 @@ msgstr "Visualiza el reloj"
 msgid "Auto-update pages"
 msgstr ""
 
-msgid "OSD height"
-msgstr "Altura OSD"
-
-msgid "OSD width"
-msgstr "Anchura OSD"
-
-msgid "OSD horizontal align"
+msgid "OSD left (%)"
 msgstr ""
 
-msgid "OSD vertical align"
+msgid "OSD top (%)"
+msgstr ""
+
+msgid "OSD width (%)"
+msgstr ""
+
+msgid "OSD height (%)"
 msgstr ""
 
 msgid "Hide mainmenu entry"
@@ -106,7 +106,10 @@ msgstr ""
 msgid "G2 code block"
 msgstr ""
 
-msgid "Color Mode 4bpp"
+msgid "Text Vertical Offset"
+msgstr ""
+
+msgid "16-Color Mode"
 msgstr ""
 
 msgid "Key bindings"
@@ -114,3 +117,9 @@ msgstr ""
 
 msgid "  Page number"
 msgstr "  Número de página"
+
+#~ msgid "OSD height"
+#~ msgstr "Altura OSD"
+
+#~ msgid "OSD width"
+#~ msgstr "Anchura OSD"

--- a/po/fi_FI.po
+++ b/po/fi_FI.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-01-27 06:22+0100\n"
+"POT-Creation-Date: 2021-02-27 06:57+0100\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Rolf Ahrenberg <rahrenbe@cc.hut.fi>\n"
 "Language-Team: Finnish <vdr@linuxtv.org>\n"
@@ -82,17 +82,17 @@ msgstr "Näytä kello"
 msgid "Auto-update pages"
 msgstr "Automaattinen sivupäivitys"
 
-msgid "OSD height"
-msgstr "Korkeus"
+msgid "OSD left (%)"
+msgstr ""
 
-msgid "OSD width"
-msgstr "Leveys"
+msgid "OSD top (%)"
+msgstr ""
 
-msgid "OSD horizontal align"
-msgstr "Pystykeskitys"
+msgid "OSD width (%)"
+msgstr ""
 
-msgid "OSD vertical align"
-msgstr "Vaakakeskitys"
+msgid "OSD height (%)"
+msgstr ""
 
 msgid "Hide mainmenu entry"
 msgstr "Piilota valinta päävalikosta"
@@ -106,7 +106,10 @@ msgstr "G0-koodilohko"
 msgid "G2 code block"
 msgstr "G2-koodilohko"
 
-msgid "Color Mode 4bpp"
+msgid "Text Vertical Offset"
+msgstr ""
+
+msgid "16-Color Mode"
 msgstr ""
 
 msgid "Key bindings"
@@ -114,3 +117,15 @@ msgstr "Näppäintoiminnot"
 
 msgid "  Page number"
 msgstr "  Sivunumero"
+
+#~ msgid "OSD height"
+#~ msgstr "Korkeus"
+
+#~ msgid "OSD width"
+#~ msgstr "Leveys"
+
+#~ msgid "OSD horizontal align"
+#~ msgstr "Pystykeskitys"
+
+#~ msgid "OSD vertical align"
+#~ msgstr "Vaakakeskitys"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-01-27 06:22+0100\n"
+"POT-Creation-Date: 2021-02-27 06:57+0100\n"
 "PO-Revision-Date: 2009-01-10 19:32+0100\n"
 "Last-Translator: Nival Michaël\n"
 "Language-Team: French <vdr@linuxtv.org>\n"
@@ -85,17 +85,17 @@ msgstr "Afficher l'heure"
 msgid "Auto-update pages"
 msgstr "Mise à jour des pages"
 
-msgid "OSD height"
-msgstr "Hauteur OSD"
+msgid "OSD left (%)"
+msgstr ""
 
-msgid "OSD width"
-msgstr "Largeur OSD"
+msgid "OSD top (%)"
+msgstr ""
 
-msgid "OSD horizontal align"
-msgstr "Alignement horizontal de l'OSD"
+msgid "OSD width (%)"
+msgstr ""
 
-msgid "OSD vertical align"
-msgstr "Alignement vertical de l'OSD"
+msgid "OSD height (%)"
+msgstr ""
 
 msgid "Hide mainmenu entry"
 msgstr ""
@@ -109,7 +109,10 @@ msgstr ""
 msgid "G2 code block"
 msgstr ""
 
-msgid "Color Mode 4bpp"
+msgid "Text Vertical Offset"
+msgstr ""
+
+msgid "16-Color Mode"
 msgstr ""
 
 msgid "Key bindings"
@@ -117,3 +120,15 @@ msgstr "Attribution des touches"
 
 msgid "  Page number"
 msgstr "  Nombre de pages"
+
+#~ msgid "OSD height"
+#~ msgstr "Hauteur OSD"
+
+#~ msgid "OSD width"
+#~ msgstr "Largeur OSD"
+
+#~ msgid "OSD horizontal align"
+#~ msgstr "Alignement horizontal de l'OSD"
+
+#~ msgid "OSD vertical align"
+#~ msgstr "Alignement vertical de l'OSD"

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-01-27 06:22+0100\n"
+"POT-Creation-Date: 2021-02-27 06:57+0100\n"
 "PO-Revision-Date: 2010-11-06 19:59+0100\n"
 "Last-Translator: Diego Pierotto <vdr-italian@tiscali.it>\n"
 "Language-Team: Italian <vdr@linuxtv.org>\n"
@@ -89,17 +89,17 @@ msgstr "Mostra orologio"
 msgid "Auto-update pages"
 msgstr "Aggiorn. automatico pagine"
 
-msgid "OSD height"
-msgstr "Altezza OSD"
+msgid "OSD left (%)"
+msgstr ""
 
-msgid "OSD width"
-msgstr "Larghezza OSD"
+msgid "OSD top (%)"
+msgstr ""
 
-msgid "OSD horizontal align"
-msgstr "Allineamento orizzontale OSD"
+msgid "OSD width (%)"
+msgstr ""
 
-msgid "OSD vertical align"
-msgstr "Allineamento verticale OSD"
+msgid "OSD height (%)"
+msgstr ""
 
 msgid "Hide mainmenu entry"
 msgstr "Nascondi voce menu principale"
@@ -113,7 +113,10 @@ msgstr ""
 msgid "G2 code block"
 msgstr ""
 
-msgid "Color Mode 4bpp"
+msgid "Text Vertical Offset"
+msgstr ""
+
+msgid "16-Color Mode"
 msgstr ""
 
 msgid "Key bindings"
@@ -121,3 +124,15 @@ msgstr "Tasti associati"
 
 msgid "  Page number"
 msgstr "  Numero pagina"
+
+#~ msgid "OSD height"
+#~ msgstr "Altezza OSD"
+
+#~ msgid "OSD width"
+#~ msgstr "Larghezza OSD"
+
+#~ msgid "OSD horizontal align"
+#~ msgstr "Allineamento orizzontale OSD"
+
+#~ msgid "OSD vertical align"
+#~ msgstr "Allineamento verticale OSD"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-01-27 06:22+0100\n"
+"POT-Creation-Date: 2021-02-27 06:57+0100\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Chris Silva <hudokkow@gmail.com>\n"
 "Language-Team: Portuguese <vdr@linuxtv.org>\n"
@@ -82,17 +82,17 @@ msgstr "Mostrar Relógio"
 msgid "Auto-update pages"
 msgstr "Auto actualizar páginas"
 
-msgid "OSD height"
-msgstr "Altura do OSD"
+msgid "OSD left (%)"
+msgstr ""
 
-msgid "OSD width"
-msgstr "Largura do OSD"
+msgid "OSD top (%)"
+msgstr ""
 
-msgid "OSD horizontal align"
-msgstr "Alinhamento Horizontal do OSD"
+msgid "OSD width (%)"
+msgstr ""
 
-msgid "OSD vertical align"
-msgstr "Alinhamento Vertical do OSD"
+msgid "OSD height (%)"
+msgstr ""
 
 msgid "Hide mainmenu entry"
 msgstr ""
@@ -106,7 +106,10 @@ msgstr ""
 msgid "G2 code block"
 msgstr ""
 
-msgid "Color Mode 4bpp"
+msgid "Text Vertical Offset"
+msgstr ""
+
+msgid "16-Color Mode"
 msgstr ""
 
 msgid "Key bindings"
@@ -114,3 +117,15 @@ msgstr "Tecla alocada"
 
 msgid "  Page number"
 msgstr "  Número de Página"
+
+#~ msgid "OSD height"
+#~ msgstr "Altura do OSD"
+
+#~ msgid "OSD width"
+#~ msgstr "Largura do OSD"
+
+#~ msgid "OSD horizontal align"
+#~ msgstr "Alinhamento Horizontal do OSD"
+
+#~ msgid "OSD vertical align"
+#~ msgstr "Alinhamento Vertical do OSD"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-01-27 06:22+0100\n"
+"POT-Creation-Date: 2021-02-27 06:57+0100\n"
 "PO-Revision-Date: 2008-12-30 13:52+0100\n"
 "Last-Translator: Andrey Pridvorov <ua0lnj@bk.ru>\n"
 "Language-Team: Russian <vdr@linuxtv.org>\n"
@@ -83,17 +83,17 @@ msgstr "Показывать часы"
 msgid "Auto-update pages"
 msgstr "Автообновление страниц"
 
-msgid "OSD height"
-msgstr "Высота меню"
+msgid "OSD left (%)"
+msgstr ""
 
-msgid "OSD width"
-msgstr "Ширина меню"
+msgid "OSD top (%)"
+msgstr ""
 
-msgid "OSD horizontal align"
-msgstr "Горизонтальное положение OSD"
+msgid "OSD width (%)"
+msgstr ""
 
-msgid "OSD vertical align"
-msgstr "Вертикальное положение OSD"
+msgid "OSD height (%)"
+msgstr ""
 
 msgid "Hide mainmenu entry"
 msgstr "Скрыть в главном меню"
@@ -107,7 +107,10 @@ msgstr "G0 кодировка"
 msgid "G2 code block"
 msgstr "G2 кодировка"
 
-msgid "Color Mode 4bpp"
+msgid "Text Vertical Offset"
+msgstr ""
+
+msgid "16-Color Mode"
 msgstr ""
 
 msgid "Key bindings"
@@ -115,3 +118,15 @@ msgstr "Привязка кнопок"
 
 msgid "  Page number"
 msgstr "  Номер страницы"
+
+#~ msgid "OSD height"
+#~ msgstr "Высота меню"
+
+#~ msgid "OSD width"
+#~ msgstr "Ширина меню"
+
+#~ msgid "OSD horizontal align"
+#~ msgstr "Горизонтальное положение OSD"
+
+#~ msgid "OSD vertical align"
+#~ msgstr "Вертикальное положение OSD"

--- a/po/sk_SK.po
+++ b/po/sk_SK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: osdteletext-0.9.0\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-01-27 06:22+0100\n"
+"POT-Creation-Date: 2021-02-27 06:57+0100\n"
 "PO-Revision-Date: 2011-02-15 21:11+0100\n"
 "Last-Translator: Milan Hrala <hrala.milan@gmail.com>\n"
 "Language-Team: Slovak <hrala.milan@gmail.com>\n"
@@ -82,17 +82,17 @@ msgstr "Zobraziť hodiny"
 msgid "Auto-update pages"
 msgstr "Aktualizácia stránok"
 
-msgid "OSD height"
-msgstr "OSD výška"
+msgid "OSD left (%)"
+msgstr ""
 
-msgid "OSD width"
-msgstr "OSD šírka"
+msgid "OSD top (%)"
+msgstr ""
 
-msgid "OSD horizontal align"
-msgstr "OSD vodorovné zarovnanie"
+msgid "OSD width (%)"
+msgstr ""
 
-msgid "OSD vertical align"
-msgstr "OSD zvyslé zarovnanie"
+msgid "OSD height (%)"
+msgstr ""
 
 msgid "Hide mainmenu entry"
 msgstr "Schovať položku v hlavnom menu"
@@ -106,7 +106,10 @@ msgstr ""
 msgid "G2 code block"
 msgstr ""
 
-msgid "Color Mode 4bpp"
+msgid "Text Vertical Offset"
+msgstr ""
+
+msgid "16-Color Mode"
 msgstr ""
 
 msgid "Key bindings"
@@ -114,3 +117,15 @@ msgstr "Klávesové skratky"
 
 msgid "  Page number"
 msgstr "  Číslo strany"
+
+#~ msgid "OSD height"
+#~ msgstr "OSD výška"
+
+#~ msgid "OSD width"
+#~ msgstr "OSD šírka"
+
+#~ msgid "OSD horizontal align"
+#~ msgstr "OSD vodorovné zarovnanie"
+
+#~ msgid "OSD vertical align"
+#~ msgstr "OSD zvyslé zarovnanie"

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-01-27 06:22+0100\n"
+"POT-Creation-Date: 2021-02-27 06:57+0100\n"
 "PO-Revision-Date: 2009-05-25 20:33+0200\n"
 "Last-Translator: Yarema P. aka Knedlyk <yupadmin@gmail.com>\n"
 "Language-Team: Ukrainian <vdr@linuxtv.org>\n"
@@ -82,17 +82,17 @@ msgstr "Показувати годинник"
 msgid "Auto-update pages"
 msgstr "Автооновлення сторінок"
 
-msgid "OSD height"
-msgstr "Висота OSD"
+msgid "OSD left (%)"
+msgstr ""
 
-msgid "OSD width"
-msgstr "Ширина OSD"
+msgid "OSD top (%)"
+msgstr ""
 
-msgid "OSD horizontal align"
-msgstr "Горизонтальне положення OSD"
+msgid "OSD width (%)"
+msgstr ""
 
-msgid "OSD vertical align"
-msgstr "Вертикальне положення OSD"
+msgid "OSD height (%)"
+msgstr ""
 
 msgid "Hide mainmenu entry"
 msgstr ""
@@ -106,7 +106,10 @@ msgstr ""
 msgid "G2 code block"
 msgstr ""
 
-msgid "Color Mode 4bpp"
+msgid "Text Vertical Offset"
+msgstr ""
+
+msgid "16-Color Mode"
 msgstr ""
 
 msgid "Key bindings"
@@ -114,3 +117,15 @@ msgstr "Призначення клавіш"
 
 msgid "  Page number"
 msgstr "  Номер сторінки"
+
+#~ msgid "OSD height"
+#~ msgstr "Висота OSD"
+
+#~ msgid "OSD width"
+#~ msgstr "Ширина OSD"
+
+#~ msgid "OSD horizontal align"
+#~ msgstr "Горизонтальне положення OSD"
+
+#~ msgid "OSD vertical align"
+#~ msgstr "Вертикальне положення OSD"

--- a/setup.h
+++ b/setup.h
@@ -42,8 +42,8 @@ public:
    int autoUpdatePage;
    int OSDheightPct;
    int OSDwidthPct;
-   int OSDvcentPct;
-   int OSDhcentPct;
+   int OSDtopPct;
+   int OSDleftPct;
    int inactivityTimeout;
    int HideMainMenu;
    cString txtFontName;

--- a/setup.h
+++ b/setup.h
@@ -42,6 +42,8 @@ public:
    int autoUpdatePage;
    int OSDheightPct;
    int OSDwidthPct;
+   int OSDvcentPct;
+   int OSDhcentPct;
    int inactivityTimeout;
    int HideMainMenu;
    cString txtFontName;


### PR DESCRIPTION
- Re-add % based top/left OSD offset 
- fix "half" mode incl. adding missing fallback to bpp=8
- other fixes and code cleanup