### PR TITLE
Adjust priority and add some additional logging

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,10 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
+2021-03-12:
+- [pbiering] decrease thread priority to "low"
+- [pbiering] add info log for thread start/stop (incl. some statistics)
+- [pbiering] add optional debug log for cTxtReceiver::DecodeTXT
+
 2021-02-28:
 - [pbiering] align plugin prefix in log, cleanup some EOL code
 - [pbiering] fix OSD background rectangle size

--- a/README
+++ b/README
@@ -117,6 +117,8 @@ Command line options:
                                   one-file-for-a-few-pages system.
      -t        --toptext          Store top text pages at cache.
                                   (unviewable pages)
+               --debugmask <MASK> Debug mask <int> or 0x<hexint>
+                                  see logging.h for details
 
 Colors:
   On all sorts of output devices which are not limited as to color depth

--- a/README
+++ b/README
@@ -117,7 +117,7 @@ Command line options:
                                   one-file-for-a-few-pages system.
      -t        --toptext          Store top text pages at cache.
                                   (unviewable pages)
-               --debugmask <MASK> Debug mask <int> or 0x<hexint>
+     -D        --debugmask <MASK> Debug mask <int> or 0x<hexint>
                                   see logging.h for details
 
 Colors:

--- a/logging.h
+++ b/logging.h
@@ -9,6 +9,8 @@ extern int m_debugmask;
 #define DEBUG_MASK_OT		0x00000001	// general
 #define DEBUG_MASK_OT_FONT	0x00010000	// Font
 #define DEBUG_MASK_OT_DBFC	0x00040000	// DisplayBase Function Call
+#define DEBUG_MASK_OT_NEPG	0x00000100	// new cTelePage
+#define DEBUG_MASK_OT_COPG	0x00000200	// regular log amount of new cTelePage
 
 // special action mask
 #define DEBUG_MASK_OT_ACT_LIMIT_LINES		0x10000000	// Limit Lines (debugging for detecting pixel offset issues)
@@ -20,5 +22,7 @@ extern int m_debugmask;
 #define DEBUG_OT	if (m_debugmask & DEBUG_MASK_OT)        dsyslog_ot
 #define DEBUG_OT_FONT	if (m_debugmask & DEBUG_MASK_OT_FONT)   dsyslog_ot
 #define DEBUG_OT_DBFC	if (m_debugmask & DEBUG_MASK_OT_DBFC)   dsyslog_ot
+#define DEBUG_OT_NEPG   if (m_debugmask & DEBUG_MASK_OT_NEPG)   dsyslog_ot
+#define DEBUG_OT_COPG   if (m_debugmask & DEBUG_MASK_OT_COPG)   dsyslog_ot
 
 #endif

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -30,7 +30,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "1.0.6.2";
+static const char *VERSION        = "1.0.6.3";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 

--- a/txtrecv.h
+++ b/txtrecv.h
@@ -54,6 +54,9 @@ private:
    bool storeTopText;
    cRingTxtFrames buffer;
    Storage *storage;
+   const cChannel* channel;
+   long int statTxtReceiverPageCount;
+   time_t statTxtReceiverTimeStart;
 protected:
    virtual void Activate(bool On);
 #if defined(APIVERSNUM) && APIVERSNUM >= 20301


### PR DESCRIPTION
- decrease thread priority to "low"
- add info log for thread start/stop (incl. some statistics)
- add optional debug log for cTxtReceiver::DecodeTXT
