### PR TITLE
Fixes related to reference

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,8 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
+2021-03-20:
+- [pbiering] extend README with hints to reference pages (hint from https://www.vdr-portal.de/forum/index.php?thread/134254-osdteletext-1-0-0-released/&postID=1338016#post1338016)
+
 2021-03-12: version 1.0.7
 - [pbiering] decrease thread priority to "low"
 - [pbiering] add info log for thread start/stop (incl. some statistics)

--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,8 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
+2021-03-21:
+- [pbiering] fix broken support of 'blink'
+
 2021-03-20:
 - [pbiering] extend README with hints to reference pages (hint from https://www.vdr-portal.de/forum/index.php?thread/134254-osdteletext-1-0-0-released/&postID=1338016#post1338016)
 

--- a/HISTORY
+++ b/HISTORY
@@ -2,6 +2,8 @@ VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
 2021-03-21:
 - [pbiering] fix broken support of 'blink'
+- [pbiering] hide clock on boxed pages
+- [pbiering] show PageId only until 1st update on boxed pages
 
 2021-03-20:
 - [pbiering] extend README with hints to reference pages (hint from https://www.vdr-portal.de/forum/index.php?thread/134254-osdteletext-1-0-0-released/&postID=1338016#post1338016)

--- a/README
+++ b/README
@@ -132,17 +132,26 @@ Colors:
 
 
 Testpages for verification
+    Page   | Reference
 
-Channel: 3sat
-  Page   | Reference
-  898-01 | https://blog.3sat.de/ttx/index.php?p=898_0001&c=0
-  898-02 | https://blog.3sat.de/ttx/index.php?p=898_0002&c=0
-  899-01 | https://blog.3sat.de/ttx/index.php?p=899_0001&c=0
-  899-02 | https://blog.3sat.de/ttx/index.php?p=899_0002&c=0
+  Channel: 3sat
+    898-01 | https://blog.3sat.de/ttx/index.php?p=898_0001&c=0
+    898-02 | https://blog.3sat.de/ttx/index.php?p=898_0002&c=0
+    899-01 | https://blog.3sat.de/ttx/index.php?p=899_0001&c=0
+    899-02 | https://blog.3sat.de/ttx/index.php?p=899_0002&c=0
 
-Channel: arte
-  199-01#
+  Channel: arte
+    199-01
 
-Channel: rbb
-  199-01
-  199-02
+  Channel: rbb
+    199-01
+    199-02
+
+
+Subtitle pages for verification
+
+  Channel: DasErste
+    150
+
+  Channel: 3sat
+    777

--- a/README
+++ b/README
@@ -147,10 +147,16 @@ Testpages for verification
     199-01
     199-02
 
+  Channel: ORF2
+    886-00
+
+  Channel: ARD https://www.ard-text.de/index.php?page=<NUM>
+    (currently none)
+
 
 Subtitle pages for verification
 
-  Channel: DasErste
+  Channel: DasErste / BR Fernsehen
     150
 
   Channel: 3sat

--- a/README
+++ b/README
@@ -139,3 +139,10 @@ Channel: 3sat
   898-02 | https://blog.3sat.de/ttx/index.php?p=898_0002&c=0
   899-01 | https://blog.3sat.de/ttx/index.php?p=899_0001&c=0
   899-02 | https://blog.3sat.de/ttx/index.php?p=899_0002&c=0
+
+Channel: arte
+  199-01#
+
+Channel: rbb
+  199-01
+  199-02

--- a/README
+++ b/README
@@ -129,3 +129,13 @@ Colors:
   The mapping is currently optimized for German ARD, ZDF and RTL. If you are
   for some reason really and definitely not satisfied with my choices, edit
   colormapping.h and recompile.
+
+
+Testpages for verification
+
+Channel: 3sat
+  Page   | Reference
+  898-01 | https://blog.3sat.de/ttx/index.php?p=898_0001&c=0
+  898-02 | https://blog.3sat.de/ttx/index.php?p=898_0002&c=0
+  899-01 | https://blog.3sat.de/ttx/index.php?p=899_0001&c=0
+  899-02 | https://blog.3sat.de/ttx/index.php?p=899_0002&c=0

--- a/display.h
+++ b/display.h
@@ -46,7 +46,7 @@ namespace Display {
     inline bool GetBlink()
         { if (display) return display->GetBlink(); else return false; }
     inline bool SetBlink(bool blink)
-        { if (display) display->SetBlink(blink); else return false; }
+        { if (display) return display->SetBlink(blink); else return false; }
     inline bool GetConceal()
         { if (display) return display->GetConceal(); else return false; }
     inline bool SetConceal(bool conceal)

--- a/displaybase.c
+++ b/displaybase.c
@@ -507,6 +507,27 @@ void cDisplay::DrawText(int x, int y, const char *text, int len) {
     Flush();
 }
 
+void cDisplay::DrawPageId(const char *text) {
+    // Draw Page ID string to OSD
+    static char text_last[9] = ""; // remember
+    DEBUG_OT_DRPI("called with text='%s' text_last='%s' Boxed=%d", text, text_last, Boxed);
+
+    if (Boxed && (strcmp(text, text_last) == 0)) {
+        // don't draw PageId a 2nd time on boxed pages
+        for (int i = 0; i < 8; i++) {
+            cTeletextChar c;
+            c.SetFGColor(ttcTransparent);
+            c.SetBGColor(ttcTransparent);
+            c.SetChar(0);
+            SetChar(i,0,c);
+        };
+        return;
+    };
+
+    DrawText(0,0,text,8);
+    strncpy(text_last, text, sizeof(text_last) - 1);
+}
+
 void cDisplay::DrawClock() {
     if (Boxed) return; // don't draw Clock in on boxed pages
 

--- a/displaybase.c
+++ b/displaybase.c
@@ -268,11 +268,11 @@ void cDisplay::RenderTeletextCode(unsigned char *PageCode) {
 
 
 void cDisplay::DrawDisplay() {
+    DEBUG_OT_DD("called with Blinked=%d Concealed=%d", Blinked, Concealed);
     int x,y;
     int cnt=0;
 
-    if (!IsDirty()) return;
-    // nothing to do
+    if (!IsDirty()) return; // nothing to do
 
     for (y = 0; y < ((ttSetup.lineMode24 == true) ? 24 : 25); y++) {
         for (x=0;x<40;x++) {
@@ -282,11 +282,11 @@ void cDisplay::DrawDisplay() {
                 cTeletextChar c=Page[x][y];
                 c.SetDirty(false);
                 if ((Blinked && c.GetBlink()) || (Concealed && c.GetConceal())) {
+                    DEBUG_OT_BLINK("blink by replacing char %08x with ' ' on x=%d y=%d", c.GetC(), x, y);
                     c.SetChar(0x20);
                     c.SetCharset(CHARSET_LATIN_G0_DE);
                 }
                 DrawChar(x,y,c);
-                Page[x][y]=c;
             }
         }
     }

--- a/displaybase.c
+++ b/displaybase.c
@@ -508,6 +508,8 @@ void cDisplay::DrawText(int x, int y, const char *text, int len) {
 }
 
 void cDisplay::DrawClock() {
+    if (Boxed) return; // don't draw Clock in on boxed pages
+
     char text[9];
     time_t t=time(0);
     struct tm loct;
@@ -558,7 +560,7 @@ void cDisplay::DrawMessage(const char *txt) {
     MessageX=x;
     MessageY=y;
 
-    dsyslog("osdteletext: DrawMessage with MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d", MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY);
+    DEBUG_OT_MSG("MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d", MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY);
 
     // And flush all changes
     ReleaseFlush();
@@ -575,7 +577,7 @@ void cDisplay::ClearMessage() {
     int x1 = (MessageX+MessageW-1-OffsetX) / (fontWidth  / 2);
     int y1 = (MessageY+MessageH-1-OffsetY) / (fontHeight / 2);
 
-    dsyslog("osdteletext: %s called with MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d => x0=%d/y0=%d x1=%d/y1=%d", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, x0, y0, x1, y1);
+    DEBUG_OT_MSG("MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d => x0=%d/y0=%d x1=%d/y1=%d", MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, x0, y0, x1, y1);
 
 #define TESTOORX(X) (X < 0 || X >= 40)
 #define TESTOORY(Y) (Y < 0 || Y >= 25)
@@ -597,7 +599,7 @@ void cDisplay::ClearMessage() {
 	if TESTOORY(y0) y0 = 25 - 1;
 	if TESTOORY(y1) y1 = 25 - 1;
     }
-    // dsyslog("osdteletext: %s: call MakeDirty with area x0=%d/y0=%d <-> x1=%d/y1=%d", __FUNCTION__, x0, y0, x1, y1);
+    // DEBUG_OT_MSG("call MakeDirty with area x0=%d/y0=%d <-> x1=%d/y1=%d", x0, y0, x1, y1);
     for (int x=x0;x<=x1;x++) {
         for (int y=y0;y<=y1;y++) {
             MakeDirty(x,y);

--- a/displaybase.c
+++ b/displaybase.c
@@ -134,6 +134,7 @@ void cDisplay::InitScaler() {
 }
 
 bool cDisplay::SetBlink(bool blink) {
+    DEBUG_OT_BLINK("called with blink=%d", blink);
     int x,y;
     bool Change=false;
 

--- a/displaybase.h
+++ b/displaybase.h
@@ -209,8 +209,7 @@ public:
     void DrawClock();
     // Draw current time to OSD
 
-    void DrawPageId(const char *text)
-        { DrawText(0,0,text,8); }
+    void DrawPageId(const char *text);
     // Draw Page ID string to OSD
 
     void DrawMessage(const char *txt);
@@ -218,7 +217,6 @@ public:
 
     void ClearMessage();
     // Remove message box and redraw hidden content
-
 
 private:
     cFont *GetFont(const char *name, int index, int height, int width);

--- a/logging.h
+++ b/logging.h
@@ -11,6 +11,8 @@ extern int m_debugmask;
 #define DEBUG_MASK_OT_NEPG	0x00000100	// new cTelePage
 #define DEBUG_MASK_OT_COPG	0x00000200	// regular log amount of new cTelePage
 #define DEBUG_MASK_OT_DD	0x00001000	// DrawDisplay
+#define DEBUG_MASK_OT_MSG	0x00002000	// Draw/Clear Message
+#define DEBUG_MASK_OT_DRPI	0x00004000	// DrawPageId
 #define DEBUG_MASK_OT_FONT	0x00010000	// Font
 #define DEBUG_MASK_OT_DBFC	0x00040000	// DisplayBase Function Call
 #define DEBUG_MASK_OT_BLINK	0x00100000	// Text Blink
@@ -30,5 +32,7 @@ extern int m_debugmask;
 #define DEBUG_OT_BLINK  if (m_debugmask & DEBUG_MASK_OT_BLINK)  dsyslog_ot
 #define DEBUG_OT_DD     if (m_debugmask & DEBUG_MASK_OT_DD)     dsyslog_ot
 #define DEBUG_OT_KNONE  if (m_debugmask & DEBUG_MASK_OT_KNONE)  dsyslog_ot
+#define DEBUG_OT_MSG    if (m_debugmask & DEBUG_MASK_OT_MSG)    dsyslog_ot
+#define DEBUG_OT_DRPI   if (m_debugmask & DEBUG_MASK_OT_DRPI)   dsyslog_ot
 
 #endif

--- a/logging.h
+++ b/logging.h
@@ -11,6 +11,7 @@ extern int m_debugmask;
 #define DEBUG_MASK_OT_DBFC	0x00040000	// DisplayBase Function Call
 #define DEBUG_MASK_OT_NEPG	0x00000100	// new cTelePage
 #define DEBUG_MASK_OT_COPG	0x00000200	// regular log amount of new cTelePage
+#define DEBUG_MASK_OT_BLINK	0x00100000	// Text Blink
 
 // special action mask
 #define DEBUG_MASK_OT_ACT_LIMIT_LINES		0x10000000	// Limit Lines (debugging for detecting pixel offset issues)
@@ -24,5 +25,6 @@ extern int m_debugmask;
 #define DEBUG_OT_DBFC	if (m_debugmask & DEBUG_MASK_OT_DBFC)   dsyslog_ot
 #define DEBUG_OT_NEPG   if (m_debugmask & DEBUG_MASK_OT_NEPG)   dsyslog_ot
 #define DEBUG_OT_COPG   if (m_debugmask & DEBUG_MASK_OT_COPG)   dsyslog_ot
+#define DEBUG_OT_BLINK  if (m_debugmask & DEBUG_MASK_OT_BLINK)  dsyslog_ot
 
 #endif

--- a/logging.h
+++ b/logging.h
@@ -7,10 +7,12 @@
 extern int m_debugmask;
 
 #define DEBUG_MASK_OT		0x00000001	// general
-#define DEBUG_MASK_OT_FONT	0x00010000	// Font
-#define DEBUG_MASK_OT_DBFC	0x00040000	// DisplayBase Function Call
+#define DEBUG_MASK_OT_KNONE	0x00000010	// Knone action
 #define DEBUG_MASK_OT_NEPG	0x00000100	// new cTelePage
 #define DEBUG_MASK_OT_COPG	0x00000200	// regular log amount of new cTelePage
+#define DEBUG_MASK_OT_DD	0x00001000	// DrawDisplay
+#define DEBUG_MASK_OT_FONT	0x00010000	// Font
+#define DEBUG_MASK_OT_DBFC	0x00040000	// DisplayBase Function Call
 #define DEBUG_MASK_OT_BLINK	0x00100000	// Text Blink
 
 // special action mask
@@ -26,5 +28,7 @@ extern int m_debugmask;
 #define DEBUG_OT_NEPG   if (m_debugmask & DEBUG_MASK_OT_NEPG)   dsyslog_ot
 #define DEBUG_OT_COPG   if (m_debugmask & DEBUG_MASK_OT_COPG)   dsyslog_ot
 #define DEBUG_OT_BLINK  if (m_debugmask & DEBUG_MASK_OT_BLINK)  dsyslog_ot
+#define DEBUG_OT_DD     if (m_debugmask & DEBUG_MASK_OT_DD)     dsyslog_ot
+#define DEBUG_OT_KNONE  if (m_debugmask & DEBUG_MASK_OT_KNONE)  dsyslog_ot
 
 #endif

--- a/menu.c
+++ b/menu.c
@@ -18,6 +18,7 @@
 #include "display.h"
 #include "setup.h"
 #include "txtrecv.h"
+#include "logging.h"
 
 #define GET_HUNDREDS(x) ( ( (x) - ((x)%256) ) /256 )
 #define GET_TENS(x)  ( (( (x) - ((x)%16) )%256 ) /16 )
@@ -167,6 +168,7 @@ eOSState TeletextBrowser::ProcessKey(eKeys Key) {
          break;        
       case kBack: return osEnd; 
       case kNone: //approx. every second
+         DEBUG_OT_KNONE("section 'kNone' reached");
          //checking if page changed
          if ( pageFound && ttSetup.autoUpdatePage && cursorPos==0 && !selectingChannel && (PageCheckSum() != checkSum) ) {
             ShowPage();
@@ -180,6 +182,11 @@ eOSState TeletextBrowser::ProcessKey(eKeys Key) {
             }
             //updating clock
             UpdateClock();
+            //trigger blink
+            bool Changed = Display::SetBlink(not(Display::GetBlink()));
+            if (Changed) {
+                // currently nothing to do
+            };
          }
          //check for activity timeout
          if (ttSetup.inactivityTimeout && (time(NULL) - lastActivity > ttSetup.inactivityTimeout*60))
@@ -667,3 +674,5 @@ TeletextSetup::TeletextSetup()
    mapKeyToAction[2]=HalfPage;   
    mapKeyToAction[0]=SwitchChannel;
 }
+
+// vim: ts=4 sw=4 et

--- a/menu.c
+++ b/menu.c
@@ -103,10 +103,10 @@ void TeletextBrowser::ChannelSwitched(int ChannelNumber) {
    IntMap::iterator it;
    channelPageMap[currentChannelNumber] = currentPage;
    currentChannelNumber=ChannelNumber;
-   
+
    currentPage=0x100;
    currentSubPage=0;
-      
+
    //see if last page number on this channel was stored
    it=channelPageMap.find(ChannelNumber);
    if (it != channelPageMap.end()) { //found
@@ -675,4 +675,4 @@ TeletextSetup::TeletextSetup()
    mapKeyToAction[0]=SwitchChannel;
 }
 
-// vim: ts=4 sw=4 et
+// vim: ts=3 sw=3 et

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -30,7 +30,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "1.0.7.dev.1";
+static const char *VERSION        = "1.0.7.dev.2";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -30,7 +30,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "1.0.7";
+static const char *VERSION        = "1.0.7.dev.1";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 

--- a/txtrender.c
+++ b/txtrender.c
@@ -272,8 +272,7 @@ void cRenderPage::ReadTeletextHeader(unsigned char *Header) {
 
 void cRenderPage::RenderTeletextCode(unsigned char *PageCode) {
     int x,y;
-    bool EmptyNextLine=false;
-    // Skip one line, in case double height chars were/will be used
+    bool EmptyNextLine=false; // Skip one line, in case double height chars were/will be used
 
     // Get code pages:
     int LocalG0CodePage=(FirstG0CodePage & 0x78) 
@@ -347,8 +346,8 @@ void cRenderPage::RenderTeletextCode(unsigned char *PageCode) {
             // Handle all 'Set-At' spacing codes
             switch (ttc) {
             case 0x09: // Steady
+                DEBUG_OT_BLINK("set bc.SetBlink(false) ttc=%d x=%d y=%d", ttc, x, y);
                 c.SetBlink(false);
-                DEBUG_OT_BLINK("SetBlink(false) ttc=%d x=%d y=%d c=%02x", ttc, x, y, c.GetC());
                 break;
             case 0x0C: // Normal Size
                 if (Size!=sizeNormal) {
@@ -475,8 +474,8 @@ void cRenderPage::RenderTeletextCode(unsigned char *PageCode) {
                 c.SetConceal(false);
                 break;
             case 0x08: // Flash
+                DEBUG_OT_BLINK("set c.SetBlink(true) ttc=%d x=%d y=%d", ttc, x, y);
                 c.SetBlink(true);
-                DEBUG_OT_BLINK("SetBlink(true) ttc=%d x=%d y=%d c=%02x", ttc, x, y, c.GetC());
                 break;
             case 0x0A: // End Box
                 c.SetBoxedOut(true);

--- a/txtrender.c
+++ b/txtrender.c
@@ -16,6 +16,7 @@
 #include <strings.h>
 #include "txtrender.h"
 #include "menu.h"
+#include "logging.h"
 
 // Font tables
 
@@ -347,6 +348,7 @@ void cRenderPage::RenderTeletextCode(unsigned char *PageCode) {
             switch (ttc) {
             case 0x09: // Steady
                 c.SetBlink(false);
+                DEBUG_OT_BLINK("SetBlink(false) ttc=%d x=%d y=%d c=%02x", ttc, x, y, c.GetC());
                 break;
             case 0x0C: // Normal Size
                 if (Size!=sizeNormal) {
@@ -474,6 +476,7 @@ void cRenderPage::RenderTeletextCode(unsigned char *PageCode) {
                 break;
             case 0x08: // Flash
                 c.SetBlink(true);
+                DEBUG_OT_BLINK("SetBlink(true) ttc=%d x=%d y=%d c=%02x", ttc, x, y, c.GetC());
                 break;
             case 0x0A: // End Box
                 c.SetBoxedOut(true);
@@ -538,4 +541,4 @@ void cRenderPage::RenderTeletextCode(unsigned char *PageCode) {
     }       
 }
 
-
+// vim: ts=4 sw=4 et


### PR DESCRIPTION
- fix broken support of 'blink'
- hide clock on boxed pages
- show PageId only until 1st update on boxed pages
- extend README with hints to reference pages (hint from https://www.vdr-portal.de/forum/index.php?thread/134254-osdteletext-1-0-0-released/&postID=1338016#post1338016)

