### PR TITLE
Fix & improve conceal

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,8 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
+2022-03-25:
+- [pbiering] fix/enable toggle support for concealed chars and hint after page number if concealed chars exist, do not display concealed chars by default
+
 2022-03-25: version 1.1.0
 - [pbiering] fix related to boxed chars in case page is not boxed itself
 

--- a/display.h
+++ b/display.h
@@ -51,7 +51,9 @@ namespace Display {
     inline bool GetConceal()
         { if (display) return display->GetConceal(); else return false; }
     inline bool SetConceal(bool conceal)
-        { if (display) display->SetConceal(conceal); else return false; }
+        { if (display) return display->SetConceal(conceal); else return false; }
+    inline bool HasConceal()
+        { if (display) return display->HasConceal(); else return false; }
     inline cDisplay::enumZoom GetZoom()
         { if (display) return display->GetZoom(); else return cDisplay::Zoom_Off; }
     inline void SetZoom(cDisplay::enumZoom zoom)

--- a/displaybase.c
+++ b/displaybase.c
@@ -515,9 +515,9 @@ void cDisplay::DrawChar(int x, int y, cTeletextChar c) {
 #if 0
             if (x == 0) {
 #else
-            if (y == 9) {
+            if (y == 2 || y == 3) {
 #endif
-                DEBUG_OT_DCHR("x=%d y=%d vx=%d vy=%d w=%d h=%d h_scale_div2=%d ttfg=%d ttbg=%d BoxedOut=%d text charset=%04x char='%s'", x, y, vx, vy, w, h, h_scale_div2, ttfg, ttbg, c.GetBoxedOut(), charset, buf);
+                DEBUG_OT_DCHR("x=%d y=%d vx=%d vy=%d w=%d h=%d h_scale_div2=%d ttfg=%d ttbg=%d BoxedOut=%d text charset=0x%04x char='%s'", x, y, vx, vy, w, h, h_scale_div2, ttfg, ttbg, c.GetBoxedOut(), charset, buf);
             };
             charBm.DrawText(0, cache_Vshift, buf, fg, 0, font, 0, h / ((h_scale_div2 == true) ? 2 : 1));
             osd->DrawBitmap(vx + leftFrame, vy + topFrame, charBm);

--- a/displaybase.h
+++ b/displaybase.h
@@ -151,6 +151,8 @@ public:
     bool SetConceal(bool conceal);
     // Hidden text. Set to true to see hidden text.
     // Returns true if there are concealed characters.
+    bool HasConceal();
+    // Returns true if there are concealed characters.
 
     enumZoom GetZoom() { return Zoom; }
     void SetZoom(enumZoom zoom);

--- a/menu.c
+++ b/menu.c
@@ -449,6 +449,12 @@ void TeletextBrowser::ExecuteAction(eTeletextAction e) {
          ShowPage();
          break;
 
+      case ToggleConceal:
+         DEBUG_OT_KEYS("key action: 'ToggleConceal' Concealed=%d -> %d", Display::GetConceal(), not(Display::GetConceal()));
+         Display::SetConceal(not(Display::GetConceal()));
+         ShowPage();
+         break;
+
       default:
          //In osdteletext.c, numbers are thought to be decimal, the setup page
          //entries will display them in this way. It is a lot easier to do the
@@ -687,6 +693,7 @@ void TeletextBrowser::ShowPage() {
 }
 
 void TeletextBrowser::ShowPageNumber() {
+   DEBUG_OT_DRPI("called with currentPage=%03x currentSubPage=%02x", currentPage, currentSubPage);
    char str[8];
    sprintf(str, "%3x-%02x", currentPage, currentSubPage);
    if (cursorPos>0) {
@@ -877,12 +884,13 @@ TeletextSetup::TeletextSetup()
    //init key bindings
    for (int i=0; i < LastActionKey; i++)
       mapKeyToAction[i]=(eTeletextAction)0;
-   mapKeyToAction[ActionKeyBlue]=Zoom;
+   mapKeyToAction[ActionKeyRed]=DarkScreen;
+   mapKeyToAction[ActionKeyGreen]=(eTeletextAction)100;
    mapKeyToAction[ActionKeyYellow]=HalfPage;
-   mapKeyToAction[ActionKeyRed]=SwitchChannel;
+   mapKeyToAction[ActionKeyBlue]=Zoom;
    mapKeyToAction[ActionKeyStop]=Config;
    mapKeyToAction[ActionKeyFastRew]=LineMode24;
-   mapKeyToAction[ActionKeyFastFwd]=DarkScreen;
+   mapKeyToAction[ActionKeyFastFwd]=ToggleConceal;
 }
 
 // vim: ts=3 sw=3 et

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -30,7 +30,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "1.1.0";
+static const char *VERSION        = "1.1.0.dev.1";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 2.4.4\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-03-25 08:17+0100\n"
+"POT-Creation-Date: 2021-03-25 21:23+0100\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Peter Bieringer <pb@bieringer.de>\n"
 "Language-Team: German <vdr@linuxtv.org>\n"
@@ -129,6 +129,9 @@ msgstr "Konfiguration"
 
 msgid "24-LineMode"
 msgstr "24-ZeilenModus"
+
+msgid "Answer"
+msgstr "Antwort"
 
 msgid "Jump to..."
 msgstr "Springe zu..."

--- a/setup.h
+++ b/setup.h
@@ -31,7 +31,7 @@
 //TeletextBrowser::TranslateKey and 
 //the constants below (st_modes)
 enum eTeletextAction { Zoom, HalfPage, SwitchChannel,
-                       DarkScreen, /*SuspendReceiving,*/ Config, LineMode24, LastAction }; //and 100-899 => jump to page
+                       DarkScreen, /*SuspendReceiving,*/ Config, LineMode24, ToggleConceal, LastAction }; //and 100-899 => jump to page
 
 enum eTeletextActionConfig {
    Left,
@@ -58,6 +58,7 @@ static const char *st_modes[] =
       //tr("Suspend receiving"),
       tr("Config"),
       tr("24-LineMode"),
+      tr("ToggleConceal"),
       tr("Jump to..."),
 };
 

--- a/setup.h
+++ b/setup.h
@@ -58,7 +58,7 @@ static const char *st_modes[] =
       //tr("Suspend receiving"),
       tr("Config"),
       tr("24-LineMode"),
-      tr("ToggleConceal"),
+      tr("Answer"),
       tr("Jump to..."),
 };
 


### PR DESCRIPTION
Concealed (hidden) text was not supported so far and always displayed. This PR fixes the issue and create a custom button command for "answer" (unhide) - also pages containing concealed text have now a mark nearby the page number