### PR TITLE
add feature "toggle pause"

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,8 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
+2022-03-28:
+- [pbiering] implement 'Paused' toggle
+
 2022-03-27:
 - [pbiering] add backgorund transparency to OSD config mode
 - [pbiering] remember background color when toggling through 'Half' mode

--- a/README
+++ b/README
@@ -81,7 +81,7 @@ Keys:
 
      Pause       :  Stop updating page (toggle)
                      OSD will display red   '*' while paused
-                     OSD will display green '>' after continue (one page further)
+                     OSD will display green '>' after release (until next page update)
 
    How to configure the key bindings:
    In the plugins setup menu, you can assign one of actions to each key.

--- a/README
+++ b/README
@@ -38,14 +38,21 @@ Keys:
    Have a look at the plugin's setup page to learn the current assignment
    and adapt it to your needs.
 
-   Available Keys: Blue, Red, Yellow, Green, Play, Stop, FastFwd, FastRwd
-   Actions: "Zoom", "Half page", "Switch channel", "Switch background",
+   Available Keys:
+	Blue, Red, Yellow, Green,
+	Stop, FastFwd, FastRwd, Ok
+
+   Actions:
+	"Zoom", "Half page", "Switch channel", "Switch background",
+	"Config", "24-Line-Mode", "Answer", "Pause"
             "Jump to..." a specific page.
 
    Description of the actions:
      Zoom:          Zoom to upper half/lower half/back to full page
+
      Half Page:     Reduce OSD window to the lower half of the screen and
                     display upper half/lower half/back to full size
+
      Switch channel:Show pages of a channel different from the one currently
                     tuned to. This does _not_ include any tuning or channel
                     switching with vdr's core. You must have tuned to the
@@ -53,16 +60,28 @@ Keys:
                     been stored on disk. When you press the key associated
                     with that action, you are asked for the channel number.
                     Press OK after you entered it with the number keys.
+
      Jump to...:    Jumps to the page you configure.
+
      Switch background: Toggles background transparency between a value
                     configured in setup, fully black, and fully transparent.
+
      Config:        Enter OSD configuration mode, currently supported
                      Left,Top +/-
                      Width,Height +/-
                      Frame +/-
                      Text Vertical Offset +/-
                      Background Transparency +/-
+
      24-Line-Mode:  Hide button line (line 25)
+
+     Answer      :  Display concealed chars (toggle)
+                     OSD will display yellow '?' in case page contains concealed chars
+                     OSD will display green  '!' while concealed chars are displayed
+
+     Pause       :  Stop updating page (toggle)
+                     OSD will display red   '*' while paused
+                     OSD will display green '>' after continue (one page further)
 
    How to configure the key bindings:
    In the plugins setup menu, you can assign one of actions to each key.

--- a/README
+++ b/README
@@ -181,6 +181,10 @@ Testpages for verification
   Channel: ARD https://www.ard-text.de/index.php?page=<NUM>
     (currently none)
 
+  Channel: ZDFinfo
+    199-01
+    199-02
+    199-03
 
 Subtitle pages for verification
 

--- a/display.h
+++ b/display.h
@@ -52,6 +52,10 @@ namespace Display {
         { if (display) return display->GetConceal(); else return false; }
     inline bool SetConceal(bool conceal)
         { if (display) return display->SetConceal(conceal); else return false; }
+    inline bool GetPaused()
+        { if (display) return display->GetPaused(); else return false; }
+    inline void SetPaused(bool paused)
+        { if (display) return display->SetPaused(paused); else return; }
     inline bool HasConceal()
         { if (display) return display->HasConceal(); else return false; }
     inline cDisplay::enumZoom GetZoom()

--- a/displaybase.c
+++ b/displaybase.c
@@ -27,6 +27,7 @@ int cDisplay::realFontWidths[4] = {0};
 cDisplay::cDisplay(int width, int height)
     : Zoom(Zoom_Off), Concealed(true), Blinked(false), FlushLock(0),
       Boxed(false), Width(width), Height(height), Background(clrGray50),
+      Paused(false),
       osd(NULL),
       outputWidth(0), outputHeight(0),
       leftFrame(0), rightFrame(0), topFrame(0), bottomFrame(0),
@@ -648,11 +649,12 @@ void cDisplay::DrawText(int x, int y, const char *text, int len) {
 void cDisplay::DrawPageId(const char *text) {
     // Draw Page ID string to OSD
     static char text_last[9] = ""; // remember
+    static bool paused_last = false;
     cTeletextChar c;
 
     DEBUG_OT_DRPI("called with text='%s' text_last='%s' Boxed=%d HasConceal=%d GetConceal=%d", text, text_last, Boxed, HasConceal(), GetConceal());
 
-    if (Boxed && (strcmp(text, text_last) == 0)) {
+    if (! GetPaused() && Boxed && (strcmp(text, text_last) == 0)) {
         // don't draw PageId a 2nd time on boxed pages
         for (int i = 0; i < 8; i++) {
             c.SetFGColor(ttcTransparent);
@@ -677,6 +679,22 @@ void cDisplay::DrawPageId(const char *text) {
         };
         DEBUG_OT_DRPI("trigger SetChar for Conceiled hint ttfg=%x ttbg=%x", c.GetFGColor(), c.GetBGColor());
         SetChar(6, 0, c);
+    };
+
+    if (GetPaused()) {
+        paused_last = true;
+        c.SetBGColor(ttcBlack);
+        c.SetFGColor(ttcRed);
+        c.SetChar('*');
+        DEBUG_OT_DRPI("trigger SetChar for Paused hint ttfg=%x ttbg=%x", c.GetFGColor(), c.GetBGColor());
+        SetChar(7, 0, c);
+    } else if (paused_last == true) {
+        paused_last = false;
+        c.SetBGColor(ttcBlack);
+        c.SetFGColor(ttcGreen);
+        c.SetChar('>');
+        DEBUG_OT_DRPI("trigger SetChar for Paused finished hint ttfg=%x ttbg=%x", c.GetFGColor(), c.GetBGColor());
+        SetChar(7, 0, c);
     };
 }
 

--- a/displaybase.h
+++ b/displaybase.h
@@ -61,6 +61,9 @@ protected:
     // Color to be used for black background
     // - allow transparency
 
+    bool Paused;
+    // Paused internal state
+
     cOsd *osd;
     // The osd object. If creation fails, may be NULL
 
@@ -153,6 +156,10 @@ public:
     // Returns true if there are concealed characters.
     bool HasConceal();
     // Returns true if there are concealed characters.
+
+    void SetPaused(bool paused) { Paused = paused; return; };
+    bool GetPaused() { return Paused; };
+    // Returns true if paused
 
     enumZoom GetZoom() { return Zoom; }
     void SetZoom(enumZoom zoom);

--- a/menu.c
+++ b/menu.c
@@ -250,7 +250,7 @@ eOSState TeletextBrowser::ProcessKey(eKeys Key) {
          ChangeSubPageRelative(DirectionForward);
          Display::ShowUpperHalf();
          ShowPage();
-         break;       
+         break;
 
       case kLeft:
          if (selectingChannel) {
@@ -272,30 +272,43 @@ eOSState TeletextBrowser::ProcessKey(eKeys Key) {
             changedConfig = ExecuteActionConfig(configMode, -1); // decrement
             break;
          };
+         // continue below
+
       case kGreen: 
          if (configMode != NotActive) { // catch config mode
             changedConfig = ExecuteActionConfig(configMode, +1); // increment
             break;
          };
+         // continue below
+
       case kYellow:
          if (configMode != NotActive) { // key is inactive in config mode (displaying value)
             break;
          };
+         // continue below
+
       case kBlue:
          if (configMode != NotActive) { // catch config mode
             ExecuteAction(Config);
             break;
          };
-      //case kUser1:case kUser2:case kUser3:case kUser4:case kUser5:
-      //case kUser6:case kUser7:case kUser8:case kUser9:
-      case kPlay:case kPause:case kStop: case kRecord:case kFastFwd:case kFastRew:
+         // continue below
+
+      case kPlay:
+      case kPause:   // not passed into plugin somehow
+      case kStop:
+      case kRecord:  // not passed into plugin somehow
+      case kFastFwd:
+      case kFastRew:
          if (cursorPos != 0) {
             //fully reset
             SetNumber(-3);
          }
          ExecuteAction(TranslateKey(Key));
          break;             
-      default: break;
+
+      default:
+         break;
    }
 
    if (changedConfig) {

--- a/menu.c
+++ b/menu.c
@@ -132,6 +132,8 @@ eOSState TeletextBrowser::ProcessKey(eKeys Key) {
    if (Key != kNone)
       lastActivity = time(NULL);
    
+   DEBUG_OT_KEYS("called with Key=%d", Key);
+
    switch (Key) {
       case k1: SetNumber(1);break;
       case k2: SetNumber(2);break;
@@ -171,7 +173,9 @@ eOSState TeletextBrowser::ProcessKey(eKeys Key) {
             } else {
                ShowPage();
             }
-         }
+         } else {
+            ExecuteAction(TranslateKey(Key));
+         };
          break;        
 
       case kBack: return osEnd; 
@@ -180,7 +184,8 @@ eOSState TeletextBrowser::ProcessKey(eKeys Key) {
          DEBUG_OT_KNONE("section 'kNone' reached");
          //checking if page changed
          if ( pageFound && ttSetup.autoUpdatePage && cursorPos==0 && !selectingChannel && (PageCheckSum() != checkSum) ) {
-            ShowPage();
+            if (! Display::GetPaused())
+               ShowPage();
          //check if page was previously not found and is available now
          } else if (!pageFound && CheckFirstSubPage(0)) {
             ShowPage();
@@ -477,6 +482,12 @@ void TeletextBrowser::ExecuteAction(eTeletextAction e) {
          ShowPage();
          break;
 
+      case TogglePause:
+         DEBUG_OT_KEYS("key action: 'TogglePause' paused=%d -> %d", Display::GetPaused(), not(Display::GetPaused()));
+         Display::SetPaused(not(Display::GetPaused())); // toggle paused status
+         ShowPage();
+         break;
+
       default:
          //In osdteletext.c, numbers are thought to be decimal, the setup page
          //entries will display them in this way. It is a lot easier to do the
@@ -529,9 +540,10 @@ eTeletextAction TeletextBrowser::TranslateKey(eKeys Key) {
       case kYellow:  return (eTeletextAction)ttSetup.mapKeyToAction[ActionKeyYellow];
       case kBlue:    return (eTeletextAction)ttSetup.mapKeyToAction[ActionKeyBlue];
       case kPlay:    return (eTeletextAction)ttSetup.mapKeyToAction[ActionKeyPlay];
-      //case kPause:   return (eTeletextAction)ttSetup.mapKeyToAction[ActionKeyPause];
+      //case kPause:   return (eTeletextAction)ttSetup.mapKeyToAction[ActionKeyPause]; // not passed into plugin somehow
+      case kOk:      return (eTeletextAction)ttSetup.mapKeyToAction[ActionKeyOk];
       case kStop:    return (eTeletextAction)ttSetup.mapKeyToAction[ActionKeyStop];
-      //case kRecord:  return (eTeletextAction)ttSetup.mapKeyToAction[ActionKeyRecord];
+      //case kRecord:  return (eTeletextAction)ttSetup.mapKeyToAction[ActionKeyRecord]; // not passed into plugin somehow
       case kFastFwd: return (eTeletextAction)ttSetup.mapKeyToAction[ActionKeyFastFwd];
       case kFastRew: return (eTeletextAction)ttSetup.mapKeyToAction[ActionKeyFastRew];
       default:       return (eTeletextAction)100; //just to keep gcc quiet
@@ -919,6 +931,7 @@ TeletextSetup::TeletextSetup()
    mapKeyToAction[ActionKeyStop]=Config;
    mapKeyToAction[ActionKeyFastRew]=LineMode24;
    mapKeyToAction[ActionKeyFastFwd]=ToggleConceal;
+   mapKeyToAction[ActionKeyOk]=TogglePause;
 }
 
 // vim: ts=3 sw=3 et

--- a/menu.c
+++ b/menu.c
@@ -295,9 +295,9 @@ eOSState TeletextBrowser::ProcessKey(eKeys Key) {
          // continue below
 
       case kPlay:
-      case kPause:   // not passed into plugin somehow
+      //case kPause:   // not passed into plugin somehow
       case kStop:
-      case kRecord:  // not passed into plugin somehow
+      //case kRecord:  // not passed into plugin somehow
       case kFastFwd:
       case kFastRew:
          if (cursorPos != 0) {

--- a/menu.h
+++ b/menu.h
@@ -58,6 +58,7 @@ protected:
    int selectingChannelNumber;
    int checkSum;
    cTxtStatus *txtStatus;
+   bool paused;
    bool suspendedReceiving;
    int previousPage;
    int previousSubPage;

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -23,6 +23,7 @@ using namespace std;
 #include "setup.h"
 #include "legacystorage.h"
 #include "packedstorage.h"
+#include "logging.h"
 
 #if defined(APIVERSNUM) && APIVERSNUM < 10739
 #error "VDR-1.7.39 API version or greater is required!"
@@ -30,7 +31,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "1.1.0.dev.4";
+static const char *VERSION        = "1.1.0.dev.5";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 
@@ -250,7 +251,8 @@ void cPluginTeletextosd::initTexts() {
       { "Action_kPlay",     trVDR("Key$Play") },
       { "Action_kStop",     trVDR("Key$Stop") },
       { "Action_kFastFwd",  trVDR("Key$FastFwd") },
-      { "Action_kFastRew",  trVDR("Key$FastRew") }
+      { "Action_kFastRew",  trVDR("Key$FastRew") },
+      { "Action_kOk",       trVDR("Key$Ok") },
    };
 
    cTeletextSetupPage::actionKeyNames = st_actionKeyNames;
@@ -472,6 +474,7 @@ cTeletextSetupPage::cTeletextSetupPage(void) {
 }
 
 eOSState cTeletextSetupPage::ProcessKey(eKeys Key) {
+   DEBUG_OT_KEYS("called with Key=%d", Key);
    eOSState state = cMenuSetupPage::ProcessKey(Key);
    if (Key != kRight && Key!=kLeft)
       return state;

--- a/po/ca_ES.po
+++ b/po/ca_ES.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-03-27 07:22+0100\n"
+"POT-Creation-Date: 2021-03-27 22:31+0100\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Jordi Vilà <jvila@tinet.org>\n"
 "Language-Team: Catalan <vdr@linuxtv.org>\n"
@@ -133,6 +133,9 @@ msgid "24-LineMode"
 msgstr ""
 
 msgid "Answer"
+msgstr ""
+
+msgid "Pause"
 msgstr ""
 
 msgid "Jump to..."

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 2.4.4\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-03-27 07:22+0100\n"
+"POT-Creation-Date: 2021-03-27 22:31+0100\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Peter Bieringer <pb@bieringer.de>\n"
 "Language-Team: German <vdr@linuxtv.org>\n"
@@ -132,6 +132,9 @@ msgstr "24-ZeilenModus"
 
 msgid "Answer"
 msgstr "Antwort"
+
+msgid "Pause"
+msgstr ""
 
 msgid "Jump to..."
 msgstr "Springe zu..."

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-03-27 07:22+0100\n"
+"POT-Creation-Date: 2021-03-27 22:31+0100\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Ruben Nunez Francisco <ruben.nunez@tang-it.com>\n"
 "Language-Team: Spanish <vdr@linuxtv.org>\n"
@@ -131,6 +131,9 @@ msgid "24-LineMode"
 msgstr ""
 
 msgid "Answer"
+msgstr ""
+
+msgid "Pause"
 msgstr ""
 
 msgid "Jump to..."

--- a/po/fi_FI.po
+++ b/po/fi_FI.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-03-27 07:22+0100\n"
+"POT-Creation-Date: 2021-03-27 22:31+0100\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Rolf Ahrenberg <rahrenbe@cc.hut.fi>\n"
 "Language-Team: Finnish <vdr@linuxtv.org>\n"
@@ -131,6 +131,9 @@ msgid "24-LineMode"
 msgstr ""
 
 msgid "Answer"
+msgstr ""
+
+msgid "Pause"
 msgstr ""
 
 msgid "Jump to..."

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-03-27 07:22+0100\n"
+"POT-Creation-Date: 2021-03-27 22:31+0100\n"
 "PO-Revision-Date: 2009-01-10 19:32+0100\n"
 "Last-Translator: Nival Michaël\n"
 "Language-Team: French <vdr@linuxtv.org>\n"
@@ -134,6 +134,9 @@ msgid "24-LineMode"
 msgstr ""
 
 msgid "Answer"
+msgstr ""
+
+msgid "Pause"
 msgstr ""
 
 msgid "Jump to..."

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-03-27 07:22+0100\n"
+"POT-Creation-Date: 2021-03-27 22:31+0100\n"
 "PO-Revision-Date: 2010-11-06 19:59+0100\n"
 "Last-Translator: Diego Pierotto <vdr-italian@tiscali.it>\n"
 "Language-Team: Italian <vdr@linuxtv.org>\n"
@@ -138,6 +138,9 @@ msgid "24-LineMode"
 msgstr ""
 
 msgid "Answer"
+msgstr ""
+
+msgid "Pause"
 msgstr ""
 
 msgid "Jump to..."

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-03-27 07:22+0100\n"
+"POT-Creation-Date: 2021-03-27 22:31+0100\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Chris Silva <hudokkow@gmail.com>\n"
 "Language-Team: Portuguese <vdr@linuxtv.org>\n"
@@ -131,6 +131,9 @@ msgid "24-LineMode"
 msgstr ""
 
 msgid "Answer"
+msgstr ""
+
+msgid "Pause"
 msgstr ""
 
 msgid "Jump to..."

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-03-27 07:22+0100\n"
+"POT-Creation-Date: 2021-03-27 22:31+0100\n"
 "PO-Revision-Date: 2008-12-30 13:52+0100\n"
 "Last-Translator: Andrey Pridvorov <ua0lnj@bk.ru>\n"
 "Language-Team: Russian <vdr@linuxtv.org>\n"
@@ -132,6 +132,9 @@ msgid "24-LineMode"
 msgstr ""
 
 msgid "Answer"
+msgstr ""
+
+msgid "Pause"
 msgstr ""
 
 msgid "Jump to..."

--- a/po/sk_SK.po
+++ b/po/sk_SK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: osdteletext-0.9.0\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-03-27 07:22+0100\n"
+"POT-Creation-Date: 2021-03-27 22:31+0100\n"
 "PO-Revision-Date: 2011-02-15 21:11+0100\n"
 "Last-Translator: Milan Hrala <hrala.milan@gmail.com>\n"
 "Language-Team: Slovak <hrala.milan@gmail.com>\n"
@@ -131,6 +131,9 @@ msgid "24-LineMode"
 msgstr ""
 
 msgid "Answer"
+msgstr ""
+
+msgid "Pause"
 msgstr ""
 
 msgid "Jump to..."

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-03-27 07:22+0100\n"
+"POT-Creation-Date: 2021-03-27 22:31+0100\n"
 "PO-Revision-Date: 2009-05-25 20:33+0200\n"
 "Last-Translator: Yarema P. aka Knedlyk <yupadmin@gmail.com>\n"
 "Language-Team: Ukrainian <vdr@linuxtv.org>\n"
@@ -131,6 +131,9 @@ msgid "24-LineMode"
 msgstr ""
 
 msgid "Answer"
+msgstr ""
+
+msgid "Pause"
 msgstr ""
 
 msgid "Jump to..."

--- a/setup.h
+++ b/setup.h
@@ -33,7 +33,7 @@
 //TeletextBrowser::TranslateKey and 
 //the constants below (st_modes)
 enum eTeletextAction { Zoom, HalfPage, SwitchChannel,
-                       DarkScreen, /*SuspendReceiving,*/ Config, LineMode24, ToggleConceal, LastAction }; //and 100-899 => jump to page
+                       DarkScreen, /*SuspendReceiving,*/ Config, LineMode24, ToggleConceal, TogglePause, LastAction }; //and 100-899 => jump to page
 
 enum eTeletextActionConfig {
    Left,
@@ -63,6 +63,7 @@ static const char *st_modes[] =
       tr("Config"),
       tr("24-LineMode"),
       tr("Answer"),
+      tr("Pause"),
       tr("Jump to..."),
 };
 
@@ -79,6 +80,7 @@ static const char *config_modes[] =
 };
 
 enum ActionKeys {
+   // keep in sync: static const ActionKeyName st_actionKeyNames in osdteletext.c
    ActionKeyRed,
    ActionKeyGreen,
    ActionKeyYellow,
@@ -87,6 +89,7 @@ enum ActionKeys {
    ActionKeyStop,
    ActionKeyFastFwd,
    ActionKeyFastRew,
+   ActionKeyOk,
 
    LastActionKey
 };
@@ -95,7 +98,7 @@ enum ActionKeys {
 class TeletextSetup {
 public:
    TeletextSetup();
-   int mapKeyToAction[10]; //4 color keys + kPlay, kPause etc.
+   int mapKeyToAction[(int) ActionKeys::LastActionKey]; //4 color keys + kPlay, kPause etc.
    unsigned int configuredClrBackground;
    int showClock;
    int suspendReceiving;

--- a/setup.h
+++ b/setup.h
@@ -98,7 +98,7 @@ enum ActionKeys {
 class TeletextSetup {
 public:
    TeletextSetup();
-   int mapKeyToAction[(int) ActionKeys::LastActionKey]; //4 color keys + kPlay, kPause etc.
+   int mapKeyToAction[(int) ActionKeys::LastActionKey]; // see enum ActionKeys
    unsigned int configuredClrBackground;
    int showClock;
    int suspendReceiving;


### PR DESCRIPTION
add a new feature name "toggle pause" which can be e.g. assigned to the "Ok" key to temporary stop updating a page. A hint sign is shown on position 7/0 in case of triggered (red "*") and released (green ">") until next page update.