### PR TITLE
fix displaying of 0x7f char

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,7 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
 2022-03-28:
+- [pbiering] fix missing implementation of graphics char 0x7f (filled rectangle)
 - [pbiering] implement 'Paused' toggle
 
 2022-03-27:

--- a/displaybase.c
+++ b/displaybase.c
@@ -379,7 +379,10 @@ void cDisplay::DrawChar(int x, int y, cTeletextChar c) {
     if (charset == CHARSET_GRAPHICS_G1 || charset == CHARSET_GRAPHICS_G1_SEP) {
         isGraphicsChar = true;
     } else {
-        isGraphicsChar = false;
+        if (c.GetChar() == 0x7f) // filled rectangle
+            isGraphicsChar = true;
+        else
+            isGraphicsChar = false;
         switch(fontType) {
             case 0:
                 font = TXTFont;

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -31,7 +31,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "1.1.0.dev.5";
+static const char *VERSION        = "1.1.0.dev.6";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 

--- a/txtfont.c
+++ b/txtfont.c
@@ -6902,7 +6902,7 @@ unsigned int* GetFontChar(cTeletextChar c, unsigned int *buffer) {
 }
 
 unsigned int GetVTXChar(cTeletextChar c) {
-    // convert  character for character/charset to utf8
+    // convert character for character/charset to utf8
     int convertedChar = 0;
     enumCharsets font = c.GetCharset();
     int chr = c.GetChar();


### PR DESCRIPTION
0x7f char (filled rectangle) was not handled as graphics char -> fixed