### PR TITLE
blacklist italic and oblique fonts

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,7 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
 2021-04-06:
+- [pbiering] blacklist Italic and Oblique fonts from being selectable (which causes anyhow issues on displaying because of kerning)
 - [pbiering] improve font scaling
 
 2021-04-04:

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -158,4 +158,4 @@ msgid "TxVoffset"
 msgstr ""
 
 msgid "BackTrans"
-msgstr "HinteTran"
+msgstr "HintGrTra"


### PR DESCRIPTION
blacklist Italic and Oblique fonts from being selectable (which causes anyhow issues on displaying because of kerning