### PR TITLE
1.9.9.dev.7 regression

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,7 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
 2021-04-07:
+- [pbiering] cached pages of non-live channel:  display page IDs in different color and a 'c' mark, do not trigger useless 'Pause'
 - [pbiering] draw bi-colored message frame, increase frame on high resolution, change font on high resolution
 
 2021-04-06:

--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,8 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
+2021-04-07:
+- [pbiering] draw bi-colored message frame, increase frame on high resolution, change font on high resolution
+
 2021-04-06:
 - [pbiering] stop updating clock and blink in case of page update was stopped
 - [pbiering] display sender name in case page is not found

--- a/display.c
+++ b/display.c
@@ -236,7 +236,7 @@ cDisplay32BPP::cDisplay32BPP(int x0, int y0, int width, int height, int leftFram
     if (bpp == 32 && (osd->CanHandleAreas(Areas, sizeof(Areas) / sizeof(tArea)) != oeOk)) {
         bpp = 8;
         Areas[0].bpp = 8;
-        dsyslog("osdteletext: OSD is not providing TrueColor, fallback to bpp=%d", bpp);
+        DEBUG_OT_AREA("osdteletext: OSD is not providing TrueColor, fallback to bpp=%d", bpp);
     }
     if (osd->CanHandleAreas(Areas, sizeof(Areas) / sizeof(tArea)) != oeOk) {
         DELETENULL(osd);
@@ -303,7 +303,7 @@ void cDisplay32BPPHalf::InitOSD() {
     if (bpp == 32 && (osd->CanHandleAreas(Areas, sizeof(Areas) / sizeof(tArea)) != oeOk)) {
         bpp = 8;
         Areas[0].bpp = 8;
-        dsyslog("osdteletext: OSD is not providing TrueColor, fallback to bpp=%d", bpp);
+        DEBUG_OT_AREA("osdteletext: OSD is not providing TrueColor, fallback to bpp=%d", bpp);
     }
     if (osd->CanHandleAreas(Areas, sizeof(Areas) / sizeof(tArea)) != oeOk) {
         DELETENULL(osd);

--- a/display.h
+++ b/display.h
@@ -84,6 +84,12 @@ namespace Display {
         { if (display) display->DrawFooter(textRed, textGreen, textYellow, textBlue, flag); }
     inline void DrawMessage(const char *txt)
         { if (display) display->DrawMessage(txt); }
+    inline void DrawMessage(const char *txt, const enumTeletextColor cFrame)
+        { if (display) display->DrawMessage(txt, cFrame); }
+    inline void DrawMessage(const char *txt, const enumTeletextColor cFrame, const enumTeletextColor cText)
+        { if (display) display->DrawMessage(txt, cFrame, cText); }
+    inline void DrawMessage(const char *txt, const enumTeletextColor cFrame, const enumTeletextColor cText, const enumTeletextColor cBackground)
+        { if (display) display->DrawMessage(txt, cFrame, cText, cBackground); }
     inline void ClearMessage()
         { if (display) display->ClearMessage(); }
 }

--- a/display.h
+++ b/display.h
@@ -80,6 +80,8 @@ namespace Display {
         { if (display) display->DrawClock(); }
     inline void DrawPageId(const char *text)
         { if (display) display->DrawPageId(text); }
+    inline void DrawPageId(const char *text, const enumTeletextColor cText)
+        { if (display) display->DrawPageId(text, cText); }
     inline void DrawFooter(const char *textRed, const char *textGreen, const char* textYellow, const char *textBlue, const FooterFlags flag)
         { if (display) display->DrawFooter(textRed, textGreen, textYellow, textBlue, flag); }
     inline void DrawMessage(const char *txt)

--- a/displaybase.c
+++ b/displaybase.c
@@ -776,15 +776,15 @@ void cDisplay::DrawFooter(const char *textRed, const char *textGreen, const char
     switch(flag) {
         case FooterNormal:
             DrawTextExtended( 0, 24, textRed   , 10, AlignmentCenter, ttcWhite, ttcRed    );
-            DrawTextExtended(10, 24, textGreen , 10, AlignmentCenter, ttcWhite, ttcGreen  );
-            DrawTextExtended(20, 24, textYellow, 10, AlignmentCenter, ttcWhite, ttcYellow );
+            DrawTextExtended(10, 24, textGreen , 10, AlignmentCenter, ttcBlack, ttcGreen  );
+            DrawTextExtended(20, 24, textYellow, 10, AlignmentCenter, ttcBlack, ttcYellow );
             DrawTextExtended(30, 24, textBlue  , 10, AlignmentCenter, ttcWhite, ttcBlue   );
             break;
 
         case FooterYellowValue:
             DrawTextExtended( 0, 24, textRed   , 10, AlignmentCenter, ttcWhite, ttcRed    );
-            DrawTextExtended(10, 24, textGreen , 10, AlignmentCenter, ttcWhite, ttcGreen  );
-            DrawTextExtended(20, 24, textYellow, 10, AlignmentCenter, ttcWhite, ttcMagenta);
+            DrawTextExtended(10, 24, textGreen , 10, AlignmentCenter, ttcBlack, ttcGreen  );
+            DrawTextExtended(20, 24, textYellow, 10, AlignmentCenter, ttcBlack, ttcMagenta);
             DrawTextExtended(30, 24, textBlue  , 10, AlignmentCenter, ttcWhite, ttcBlue   );
             break;
 

--- a/displaybase.c
+++ b/displaybase.c
@@ -784,7 +784,7 @@ void cDisplay::DrawFooter(const char *textRed, const char *textGreen, const char
         case FooterYellowValue:
             DrawTextExtended( 0, 24, textRed   , 10, AlignmentCenter, ttcWhite, ttcRed    );
             DrawTextExtended(10, 24, textGreen , 10, AlignmentCenter, ttcBlack, ttcGreen  );
-            DrawTextExtended(20, 24, textYellow, 10, AlignmentCenter, ttcBlack, ttcMagenta);
+            DrawTextExtended(20, 24, textYellow, 10, AlignmentCenter, ttcWhite, ttcMagenta);
             DrawTextExtended(30, 24, textBlue  , 10, AlignmentCenter, ttcWhite, ttcBlue   );
             break;
 

--- a/displaybase.c
+++ b/displaybase.c
@@ -757,7 +757,7 @@ void cDisplay::DrawPageId(const char *text) {
         paused_last = true;
         c.SetBGColor(ttcBlack);
         c.SetFGColor(ttcRed);
-        c.SetChar('*');
+        c.SetChar('!');
         DEBUG_OT_DRPI("trigger SetChar for Paused hint ttfg=%x ttbg=%x", c.GetFGColor(), c.GetBGColor());
         SetChar(7, 0, c);
     } else if (paused_last == true) {

--- a/displaybase.c
+++ b/displaybase.c
@@ -689,12 +689,12 @@ void cDisplay::DrawTextExtended(const int x, const int y, const char *text, cons
     Flush();
 };
 
-void cDisplay::DrawText(int x, int y, const char *text, int len) {
+void cDisplay::DrawText(int x, int y, const char *text, int len, const enumTeletextColor cText) {
     // Copy text to teletext page
     DEBUG_OT_DTXT("called with x=%d y=%d len=%d text='%s' strlen(text)=%ld", x, y, len, text, strlen(text));
 
     cTeletextChar c;
-    c.SetFGColor(ttcWhite);
+    c.SetFGColor(cText); // default ttcWhite
     c.SetBGColor(ttcBlack);
     c.SetCharset(CHARSET_LATIN_G0);
 
@@ -718,7 +718,7 @@ void cDisplay::DrawText(int x, int y, const char *text, int len) {
     Flush();
 }
 
-void cDisplay::DrawPageId(const char *text) {
+void cDisplay::DrawPageId(const char *text, const enumTeletextColor cText) {
     // Draw Page ID string to OSD
     static char text_last[9] = ""; // remember
     static bool paused_last = false;
@@ -737,7 +737,7 @@ void cDisplay::DrawPageId(const char *text) {
         return;
     };
 
-    DrawText(0,0,text,8);
+    DrawText(0,0,text,8, cText);
     strncpy(text_last, text, sizeof(text_last) - 1);
 
     if (HasConceal()) {

--- a/displaybase.h
+++ b/displaybase.h
@@ -217,7 +217,7 @@ public:
     // and draw the whole page content into OSD.
     // PageCode must be a 40*24+12 bytes buffer
 
-    void DrawText(int x, int y, const char *text, int len);
+    void DrawText(int x, int y, const char *text, int len, const enumTeletextColor cText = ttcWhite);
     // Draw some characters in teletext page.
     // Max len chars, fill up with spaces
 
@@ -232,8 +232,8 @@ public:
     void DrawClock();
     // Draw current time to OSD
 
-    void DrawPageId(const char *text);
-    // Draw Page ID string to OSD
+    void DrawPageId(const char *text, const enumTeletextColor cText = ttcWhite);
+    // Draw Page ID string to OSD with optional text color
 
     void DrawMessage(const char *txt, const enumTeletextColor cFrame = ttcWhite, const enumTeletextColor cText = ttcWhite, const enumTeletextColor cBackground = ttcBlack);
     // Draw a framed, centered message box to OSD with optional(default) color definition for frame(white), text(white), background(black)

--- a/displaybase.h
+++ b/displaybase.h
@@ -235,8 +235,8 @@ public:
     void DrawPageId(const char *text);
     // Draw Page ID string to OSD
 
-    void DrawMessage(const char *txt);
-    // Draw a framed, centered message box to OSD
+    void DrawMessage(const char *txt, const enumTeletextColor cFrame = ttcWhite, const enumTeletextColor cText = ttcWhite, const enumTeletextColor cBackground = ttcBlack);
+    // Draw a framed, centered message box to OSD with optional(default) color definition for frame(white), text(white), background(black)
 
     void ClearMessage();
     // Remove message box and redraw hidden content

--- a/menu.c
+++ b/menu.c
@@ -818,11 +818,7 @@ bool TeletextBrowser::DecodePage() {
       Display::HoldFlush();
       ShowPageNumber();
       char str[80];
-      snprintf(str,80, "%s %3x-%02x %s%s%s%s",tr("Page"),currentPage, currentSubPage,tr("not found")
-         , ((currentPage == 0x100) && (currentSubPage == 0)) ? " (" : ""
-         , ((currentPage == 0x100) && (currentSubPage == 0)) ? channelClass.Name() : ""
-         , ((currentPage == 0x100) && (currentSubPage == 0)) ? ")" : ""
-      );
+      snprintf(str,80, "%s %3x-%02x %s (%s)",tr("Page"),currentPage, currentSubPage,tr("not found"), channelClass.Name());
       Display::DrawMessage(str);
       Display::ReleaseFlush();
 

--- a/menu.c
+++ b/menu.c
@@ -43,6 +43,7 @@ int TeletextBrowser::currentSubPage=0;
 tChannelID TeletextBrowser::channel;
 cChannel TeletextBrowser::channelClass;
 int TeletextBrowser::currentChannelNumber=0;
+int TeletextBrowser::liveChannelNumber=0;
 TeletextBrowser* TeletextBrowser::self=0;
 
 eTeletextActionConfig configMode = NotActive;
@@ -85,7 +86,7 @@ bool TeletextBrowser::CheckIsValidChannel(int number) {
 #endif
 }
 
-void TeletextBrowser::ChannelSwitched(int ChannelNumber) {
+void TeletextBrowser::ChannelSwitched(int ChannelNumber, const bool live) {
 #if defined(APIVERSNUM) && APIVERSNUM >= 20301
    LOCK_CHANNELS_READ;
    const cChannel *chan=Channels->GetByNumber(ChannelNumber);
@@ -102,6 +103,9 @@ void TeletextBrowser::ChannelSwitched(int ChannelNumber) {
       
    channel=chid;
    channelClass = *chan; // remember for later to display channel name
+
+   if (live)
+      liveChannelNumber= ChannelNumber; // remember active live channel
    
    //store page number of current channel
    IntMap::iterator it;

--- a/menu.c
+++ b/menu.c
@@ -455,9 +455,9 @@ void TeletextBrowser::ExecuteAction(eTeletextAction e) {
       case SwitchChannel:
          DEBUG_OT_KEYS("key action: 'SwitchChannel'");
          if (!selectingChannel) {
-            selectingChannelNumber=0;
-            selectingChannel=true;
-            ShowAskForChannel();
+             selectingChannelNumber=0;
+             selectingChannel=true;
+             ShowAskForChannel();
          } else {
              selectingChannel=false;
              Display::ClearMessage();

--- a/menu.c
+++ b/menu.c
@@ -872,7 +872,7 @@ void TeletextBrowser::UpdateFooter() {
       if (mode < 100) { \
          snprintf(text, sizeof(text), "%s", st_modesFooter[mode]); \
       } else if (mode < 999) { \
-         snprintf(text, sizeof(text), "->%03d", mode); \
+         snprintf(text, sizeof(text), "-> %03d", mode); \
       } else { \
          snprintf(text, sizeof(text), "ERROR"); \
       }; \

--- a/menu.c
+++ b/menu.c
@@ -820,6 +820,7 @@ bool TeletextBrowser::DecodePage() {
       char str[80];
       snprintf(str,80, "%s %3x-%02x %s (%s)",tr("Page"),currentPage, currentSubPage,tr("not found"), channelClass.Name());
       Display::DrawMessage(str);
+      UpdateFooter();
       Display::ReleaseFlush();
 
       return false;

--- a/menu.c
+++ b/menu.c
@@ -541,9 +541,14 @@ void TeletextBrowser::ExecuteAction(eTeletextAction e) {
          break;
 
       case TogglePause:
-         DEBUG_OT_KEYS("key action: 'TogglePause' paused=%d -> %d", Display::GetPaused(), not(Display::GetPaused()));
-         Display::SetPaused(not(Display::GetPaused())); // toggle paused status
-         ShowPage();
+         if (liveChannelNumber == currentChannelNumber) {
+            DEBUG_OT_KEYS("key action: 'TogglePause' paused=%d -> %d", Display::GetPaused(), not(Display::GetPaused()));
+            // toggle paused status only if live channel (otherwise useless)
+            Display::SetPaused(not(Display::GetPaused()));
+            ShowPage();
+         } else {
+            DEBUG_OT_KEYS("key action: 'TogglePause' useless, currently not a live channel on OSD");
+         };
          break;
 
       default:
@@ -786,14 +791,20 @@ void TeletextBrowser::ShowPage() {
 
 void TeletextBrowser::ShowPageNumber() {
    DEBUG_OT_DRPI("called with currentPage=%03x currentSubPage=%02x", currentPage, currentSubPage);
-   char str[8];
-   sprintf(str, "%3x-%02x", currentPage, currentSubPage);
+   char str[9];
+   snprintf(str, sizeof(str), "%3x-%02x %s", currentPage, currentSubPage
+      , (liveChannelNumber != currentChannelNumber) ? "c" : "" // cache mark
+   );
    if (cursorPos>0) {
       str[2]='*';
       if (cursorPos==1)
          str[1]='*';
    }
-   Display::DrawPageId(str);
+
+   if (liveChannelNumber != currentChannelNumber)
+      Display::DrawPageId(str, ttcCyan); // colored
+   else
+      Display::DrawPageId(str);
 }
 
 void TeletextBrowser::ShowAskForChannel() {

--- a/menu.c
+++ b/menu.c
@@ -454,9 +454,14 @@ void TeletextBrowser::ExecuteAction(eTeletextAction e) {
 
       case SwitchChannel:
          DEBUG_OT_KEYS("key action: 'SwitchChannel'");
-         selectingChannelNumber=0;
-         selectingChannel=true;
-         ShowAskForChannel();
+         if (!selectingChannel) {
+            selectingChannelNumber=0;
+            selectingChannel=true;
+            ShowAskForChannel();
+         } else {
+             selectingChannel=false;
+             Display::ClearMessage();
+         };
          break;
 
       /*case SuspendReceiving:

--- a/menu.c
+++ b/menu.c
@@ -120,6 +120,17 @@ void TeletextBrowser::ChannelSwitched(int ChannelNumber, const bool live) {
    if (it != channelPageMap.end()) { //found
       currentPage=(*it).second;
    }
+
+   char str[80];
+   if (liveChannelNumber != currentChannelNumber)
+      snprintf(str, sizeof(str), "%s %s: %s", tr("Switch to cached"), tr("Channel"), channelClass.Name());
+   else if (live)
+      snprintf(str, sizeof(str), "%s %s: %s", tr("Switch to live"), tr("Channel"), channelClass.Name());
+   else
+      snprintf(str, sizeof(str), "%s %s: %s", tr("Switch back to live"), tr("Channel"), channelClass.Name());
+
+   Display::DrawMessage(str, ttcBlue);
+   sleep(1);
    
    //on the one hand this must work in background mode, when the plugin is not active.
    //on the other hand, if active, the page should be shown.
@@ -175,9 +186,10 @@ eOSState TeletextBrowser::ProcessKey(eKeys Key) {
                   ChannelSwitched(selectingChannelNumber);
                else {
                   needClearMessage=true;
-                  Display::DrawMessage(trVDR("*** Invalid Channel ***"));
+                  Display::DrawMessage(trVDR("*** Invalid Channel ***"), ttcRed);
                }
             } else {
+               ChannelSwitched(liveChannelNumber);
                ShowPage();
             }
          } else {
@@ -505,7 +517,7 @@ void TeletextBrowser::ExecuteAction(eTeletextAction e) {
          if (ttSetup.lineMode24) {
             // config mode is only supported in 25-line mode
             Display::ClearMessage();
-            Display::DrawMessage(tr("*** Config mode is not supported in 24-line mode ***"));
+            Display::DrawMessage(tr("*** Config mode is not supported in 24-line mode ***"), ttcRed);
             break;
          };
          switch(configMode) {
@@ -787,7 +799,7 @@ void TeletextBrowser::ShowPageNumber() {
 void TeletextBrowser::ShowAskForChannel() {
    if (selectingChannel) {
       cString str = cString::sprintf(selectingChannelNumber > 0 ? "%s%d" : "%s", tr("Channel (press OK): "), selectingChannelNumber);
-      Display::DrawMessage(str);
+      Display::DrawMessage(str, ttcBlue);
    }
 }
 
@@ -827,8 +839,11 @@ bool TeletextBrowser::DecodePage() {
       Display::HoldFlush();
       ShowPageNumber();
       char str[80];
-      snprintf(str,80, "%s %3x-%02x %s (%s)",tr("Page"),currentPage, currentSubPage,tr("not found"), channelClass.Name());
-      Display::DrawMessage(str);
+      snprintf(str, sizeof(str), "%s %3x-%02x %s %s (%s)",tr("Page"),currentPage, currentSubPage
+            , (liveChannelNumber != currentChannelNumber) ? tr("in cache") : ""
+            , tr("not found"), channelClass.Name()
+      );
+      Display::DrawMessage(str, ttcYellow);
       UpdateFooter();
       Display::ReleaseFlush();
 

--- a/menu.h
+++ b/menu.h
@@ -28,7 +28,7 @@ public:
    TeletextBrowser(cTxtStatus *txtSt,Storage *s);
    ~TeletextBrowser();
    void Show(void);
-   static void ChannelSwitched(int ChannelNumber);
+   static void ChannelSwitched(int ChannelNumber, const bool live = false);
    virtual eOSState ProcessKey(eKeys Key);
 protected:
    enum Direction { DirectionForward, DirectionBackward };
@@ -71,6 +71,7 @@ protected:
    static tChannelID channel; // TODO: rename to channelId
    static cChannel channelClass;
    static int currentChannelNumber;
+   static int liveChannelNumber;
    static TeletextBrowser* self;
    Storage *storage;
 private:

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -32,7 +32,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "1.9.9.dev.6";
+static const char *VERSION        = "1.9.9.dev.7";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 

--- a/po/ca_ES.po
+++ b/po/ca_ES.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-06 17:47+0200\n"
+"POT-Creation-Date: 2021-04-07 08:43+0200\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Jordi Vilà <jvila@tinet.org>\n"
 "Language-Team: Catalan <vdr@linuxtv.org>\n"
@@ -17,6 +17,18 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+msgid "Switch to cached"
+msgstr ""
+
+msgid "Channel"
+msgstr ""
+
+msgid "Switch to live"
+msgstr ""
+
+msgid "Switch back to live"
+msgstr ""
 
 msgid "*** Config mode is not supported in 24-line mode ***"
 msgstr ""
@@ -26,6 +38,9 @@ msgstr "Canal (premi OK):"
 
 msgid "Page"
 msgstr "Pàgina"
+
+msgid "in cache"
+msgstr ""
 
 msgid "not found"
 msgstr "no trobada"

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 2.4.4\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-06 17:47+0200\n"
+"POT-Creation-Date: 2021-04-07 08:43+0200\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Peter Bieringer <pb@bieringer.de>\n"
 "Language-Team: German <vdr@linuxtv.org>\n"
@@ -15,6 +15,18 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+msgid "Switch to cached"
+msgstr "Wechsle zu gespeicherten"
+
+msgid "Channel"
+msgstr "Kanal"
+
+msgid "Switch to live"
+msgstr "Wechsle zu laufendem"
+
+msgid "Switch back to live"
+msgstr "Wechsle zurück zu laufendem"
 
 msgid "*** Config mode is not supported in 24-line mode ***"
 msgstr "*** Konfig-Modus ist im 24-Zeilen-Modus nicht unterstützt ***"
@@ -24,6 +36,9 @@ msgstr "Sender (OK drücken): "
 
 msgid "Page"
 msgstr "Seite"
+
+msgid "in cache"
+msgstr "im Speicher"
 
 msgid "not found"
 msgstr "nicht gefunden"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-06 17:47+0200\n"
+"POT-Creation-Date: 2021-04-07 08:43+0200\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Ruben Nunez Francisco <ruben.nunez@tang-it.com>\n"
 "Language-Team: Spanish <vdr@linuxtv.org>\n"
@@ -15,6 +15,18 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+msgid "Switch to cached"
+msgstr ""
+
+msgid "Channel"
+msgstr ""
+
+msgid "Switch to live"
+msgstr ""
+
+msgid "Switch back to live"
+msgstr ""
 
 msgid "*** Config mode is not supported in 24-line mode ***"
 msgstr ""
@@ -24,6 +36,9 @@ msgstr "Canal (pulse OK):"
 
 msgid "Page"
 msgstr "Página"
+
+msgid "in cache"
+msgstr ""
 
 msgid "not found"
 msgstr "no encontrada"

--- a/po/fi_FI.po
+++ b/po/fi_FI.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-06 17:47+0200\n"
+"POT-Creation-Date: 2021-04-07 08:43+0200\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Rolf Ahrenberg <rahrenbe@cc.hut.fi>\n"
 "Language-Team: Finnish <vdr@linuxtv.org>\n"
@@ -15,6 +15,18 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+msgid "Switch to cached"
+msgstr ""
+
+msgid "Channel"
+msgstr ""
+
+msgid "Switch to live"
+msgstr ""
+
+msgid "Switch back to live"
+msgstr ""
 
 msgid "*** Config mode is not supported in 24-line mode ***"
 msgstr ""
@@ -24,6 +36,9 @@ msgstr "Kanava (paina OK):"
 
 msgid "Page"
 msgstr "Sivua"
+
+msgid "in cache"
+msgstr ""
 
 msgid "not found"
 msgstr "ei löydy"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-06 17:47+0200\n"
+"POT-Creation-Date: 2021-04-07 08:43+0200\n"
 "PO-Revision-Date: 2009-01-10 19:32+0100\n"
 "Last-Translator: Nival Michaël\n"
 "Language-Team: French <vdr@linuxtv.org>\n"
@@ -18,6 +18,18 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+msgid "Switch to cached"
+msgstr ""
+
+msgid "Channel"
+msgstr ""
+
+msgid "Switch to live"
+msgstr ""
+
+msgid "Switch back to live"
+msgstr ""
 
 msgid "*** Config mode is not supported in 24-line mode ***"
 msgstr ""
@@ -27,6 +39,9 @@ msgstr "Chaine (Appuyer sur OK): "
 
 msgid "Page"
 msgstr "Page"
+
+msgid "in cache"
+msgstr ""
 
 msgid "not found"
 msgstr "pas trouvé"

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-06 17:47+0200\n"
+"POT-Creation-Date: 2021-04-07 08:43+0200\n"
 "PO-Revision-Date: 2010-11-06 19:59+0100\n"
 "Last-Translator: Diego Pierotto <vdr-italian@tiscali.it>\n"
 "Language-Team: Italian <vdr@linuxtv.org>\n"
@@ -23,6 +23,18 @@ msgstr ""
 "X-Poedit-Country: ITALY\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
+msgid "Switch to cached"
+msgstr ""
+
+msgid "Channel"
+msgstr ""
+
+msgid "Switch to live"
+msgstr ""
+
+msgid "Switch back to live"
+msgstr ""
+
 msgid "*** Config mode is not supported in 24-line mode ***"
 msgstr ""
 
@@ -31,6 +43,9 @@ msgstr "Canale (premi OK): "
 
 msgid "Page"
 msgstr "Pagina"
+
+msgid "in cache"
+msgstr ""
 
 msgid "not found"
 msgstr "non trovata"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-06 17:47+0200\n"
+"POT-Creation-Date: 2021-04-07 08:43+0200\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Chris Silva <hudokkow@gmail.com>\n"
 "Language-Team: Portuguese <vdr@linuxtv.org>\n"
@@ -15,6 +15,18 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+msgid "Switch to cached"
+msgstr ""
+
+msgid "Channel"
+msgstr ""
+
+msgid "Switch to live"
+msgstr ""
+
+msgid "Switch back to live"
+msgstr ""
 
 msgid "*** Config mode is not supported in 24-line mode ***"
 msgstr ""
@@ -24,6 +36,9 @@ msgstr "Sender (Prima OK): "
 
 msgid "Page"
 msgstr "Página"
+
+msgid "in cache"
+msgstr ""
 
 msgid "not found"
 msgstr "Não encontrado"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-06 17:47+0200\n"
+"POT-Creation-Date: 2021-04-07 08:43+0200\n"
 "PO-Revision-Date: 2008-12-30 13:52+0100\n"
 "Last-Translator: Andrey Pridvorov <ua0lnj@bk.ru>\n"
 "Language-Team: Russian <vdr@linuxtv.org>\n"
@@ -16,6 +16,18 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+msgid "Switch to cached"
+msgstr ""
+
+msgid "Channel"
+msgstr ""
+
+msgid "Switch to live"
+msgstr ""
+
+msgid "Switch back to live"
+msgstr ""
 
 msgid "*** Config mode is not supported in 24-line mode ***"
 msgstr ""
@@ -25,6 +37,9 @@ msgstr "Канал (Нажмите ОК)"
 
 msgid "Page"
 msgstr "Страница"
+
+msgid "in cache"
+msgstr ""
 
 msgid "not found"
 msgstr "не найдена"

--- a/po/sk_SK.po
+++ b/po/sk_SK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: osdteletext-0.9.0\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-06 17:47+0200\n"
+"POT-Creation-Date: 2021-04-07 08:43+0200\n"
 "PO-Revision-Date: 2011-02-15 21:11+0100\n"
 "Last-Translator: Milan Hrala <hrala.milan@gmail.com>\n"
 "Language-Team: Slovak <hrala.milan@gmail.com>\n"
@@ -15,6 +15,18 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+msgid "Switch to cached"
+msgstr ""
+
+msgid "Channel"
+msgstr ""
+
+msgid "Switch to live"
+msgstr ""
+
+msgid "Switch back to live"
+msgstr ""
 
 msgid "*** Config mode is not supported in 24-line mode ***"
 msgstr ""
@@ -24,6 +36,9 @@ msgstr "Kanál (stlačte OK): "
 
 msgid "Page"
 msgstr "Strana"
+
+msgid "in cache"
+msgstr ""
 
 msgid "not found"
 msgstr "nenájdená"

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-06 17:47+0200\n"
+"POT-Creation-Date: 2021-04-07 08:43+0200\n"
 "PO-Revision-Date: 2009-05-25 20:33+0200\n"
 "Last-Translator: Yarema P. aka Knedlyk <yupadmin@gmail.com>\n"
 "Language-Team: Ukrainian <vdr@linuxtv.org>\n"
@@ -15,6 +15,18 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+msgid "Switch to cached"
+msgstr ""
+
+msgid "Channel"
+msgstr ""
+
+msgid "Switch to live"
+msgstr ""
+
+msgid "Switch back to live"
+msgstr ""
 
 msgid "*** Config mode is not supported in 24-line mode ***"
 msgstr ""
@@ -24,6 +36,9 @@ msgstr "Канал (натисніть ОК): "
 
 msgid "Page"
 msgstr "Сторінка"
+
+msgid "in cache"
+msgstr ""
 
 msgid "not found"
 msgstr "не знайдена"

--- a/txtrecv.c
+++ b/txtrecv.c
@@ -246,7 +246,7 @@ void cTxtStatus::ChannelSwitch(const cDevice *Device, int ChannelNumber, bool Li
       cDevice::ActualDevice()->AttachReceiver(receiver);
    }
 
-   TeletextBrowser::ChannelSwitched(ChannelNumber);
+   TeletextBrowser::ChannelSwitched(ChannelNumber, true);
 }
 
 


### PR DESCRIPTION
- cached pages of non-live channel:  display page IDs in different color and a 'c' mark, do not trigger useless 'Pause'
- draw bi-colored message frame, increase frame on high resolution, change font on high resolution
