### PR TITLE
1.9.9.dev.8 regression

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,9 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
+2021-04-08:
+- [pbiering] many fixes found during regression tests
+- [pbiering] display PageId always in case OSD was restarted (useful e.g. for subtitle pages)
+
 2021-04-07:
 - [pbiering] cached pages of non-live channel:  display page IDs in different color and a 'c' mark, do not trigger useless 'Pause'
 - [pbiering] channel switch: display message, on empty OK return to live channel

--- a/HISTORY
+++ b/HISTORY
@@ -1,8 +1,9 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
 2021-04-08:
-- [pbiering] many fixes found during regression tests
+- [pbiering] many fixes found during regression tests related to MessageBox, too often CleanDisplay calls, ...
 - [pbiering] display PageId always in case OSD was restarted (useful e.g. for subtitle pages)
+- [pbiering] selected background color kept on OSD restart
 
 2021-04-07:
 - [pbiering] cached pages of non-live channel:  display page IDs in different color and a 'c' mark, do not trigger useless 'Pause'

--- a/HISTORY
+++ b/HISTORY
@@ -2,6 +2,7 @@ VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
 2021-04-07:
 - [pbiering] cached pages of non-live channel:  display page IDs in different color and a 'c' mark, do not trigger useless 'Pause'
+- [pbiering] channel switch: display message, on empty OK return to live channel
 - [pbiering] draw bi-colored message frame, increase frame on high resolution, change font on high resolution
 
 2021-04-06:

--- a/display.c
+++ b/display.c
@@ -140,6 +140,7 @@ void Display::SetMode(Display::Mode NewMode, tColor Background) {
     switch (NewMode) {
       case Display::Full:
         // Need to re-initialize *display:
+        DEBUG_OT_DBFC("osdteletext: OSD 'full' Full->reinit display");
         Delete();
         // Try 32BPP display first:
         display=new cDisplay32BPP(x0,y0,OSDwidth,OSDheight,OSDleftFrame,OSDrightFrame,OSDtopFrame,OSDbottomFrame);
@@ -147,6 +148,7 @@ void Display::SetMode(Display::Mode NewMode, tColor Background) {
       case Display::HalfUpper:
         // Shortcut to switch from HalfUpper to HalfLower:
         if (mode==Display::HalfLower) {
+            DEBUG_OT_DBFC("osdteletext: OSD 'half' shortcut HalfUpper->HalfLower");
             // keep instance.
             ((cDisplay32BPPHalf*)display)->SetZoom(cDisplay::Zoom_Upper);
             ((cDisplay32BPPHalf*)display)->SetUpper(true);
@@ -154,6 +156,7 @@ void Display::SetMode(Display::Mode NewMode, tColor Background) {
             break;
         }
         // Need to re-initialize *display:
+        DEBUG_OT_DBFC("osdteletext: OSD 'half' HalfUpper->reinit display");
         Delete();
         display=new cDisplay32BPPHalf(x0,y0,OSDwidth,OSDheight,OSDleftFrame,OSDrightFrame,OSDtopFrame,OSDbottomFrame,true,false);
         ((cDisplay32BPPHalf*)display)->SetZoom(cDisplay::Zoom_Upper);
@@ -168,6 +171,7 @@ void Display::SetMode(Display::Mode NewMode, tColor Background) {
             break;
         }
         // Need to re-initialize *display:
+        DEBUG_OT_DBFC("osdteletext: OSD 'half' HalfUpperTop->reinit display");
         Delete();
         display=new cDisplay32BPPHalf(x0,y0,OSDwidth,OSDheight,OSDleftFrame,OSDrightFrame,OSDtopFrame,OSDbottomFrame,true,true);
         ((cDisplay32BPPHalf*)display)->SetZoom(cDisplay::Zoom_Upper);
@@ -175,6 +179,7 @@ void Display::SetMode(Display::Mode NewMode, tColor Background) {
       case Display::HalfLower:
         // Shortcut to switch from HalfUpper to HalfLower:
         if (mode==Display::HalfUpper) {
+            DEBUG_OT_DBFC("osdteletext: OSD 'half' shortcut HalfLower->HalfUpper");
             // keep instance.
             ((cDisplay32BPPHalf*)display)->SetZoom(cDisplay::Zoom_Lower);
             ((cDisplay32BPPHalf*)display)->SetUpper(false);
@@ -182,6 +187,7 @@ void Display::SetMode(Display::Mode NewMode, tColor Background) {
             break;
         }
         // Need to re-initialize *display:
+        DEBUG_OT_DBFC("osdteletext: OSD 'half' HalfLower->reinit display");
         Delete();
         display=new cDisplay32BPPHalf(x0,y0,OSDwidth,OSDheight,OSDleftFrame,OSDrightFrame,OSDtopFrame,OSDbottomFrame,false,false);
         ((cDisplay32BPPHalf*)display)->SetZoom(cDisplay::Zoom_Lower);
@@ -189,6 +195,7 @@ void Display::SetMode(Display::Mode NewMode, tColor Background) {
       case Display::HalfLowerTop:
         // Shortcut to switch from HalfUpperTop to HalfLowerTop:
         if (mode==Display::HalfUpperTop) {
+            DEBUG_OT_DBFC("osdteletext: OSD 'half' shortcut HalfUpperTop->HalfLowerTop");
             // keep instance.
             ((cDisplay32BPPHalf*)display)->SetZoom(cDisplay::Zoom_Lower);
             ((cDisplay32BPPHalf*)display)->SetUpper(false);
@@ -196,6 +203,7 @@ void Display::SetMode(Display::Mode NewMode, tColor Background) {
             break;
         }
         // Need to re-initialize *display:
+        DEBUG_OT_DBFC("osdteletext: OSD 'half' HalfLowerTop->reinit display");
         Delete();
         display=new cDisplay32BPPHalf(x0,y0,OSDwidth,OSDheight,OSDleftFrame,OSDrightFrame,OSDtopFrame,OSDbottomFrame,false,true);
         ((cDisplay32BPPHalf*)display)->SetZoom(cDisplay::Zoom_Lower);

--- a/display.c
+++ b/display.c
@@ -365,6 +365,7 @@ void cDisplay32BPPHalf::InitOSD() {
     InitScaler();
 
     // In case we switched on the fly, do a full redraw
+    CleanDisplay();
     Dirty=true;
     DirtyAll=true;
     Flush();

--- a/display.h
+++ b/display.h
@@ -33,7 +33,7 @@ namespace Display {
     extern cDisplay *display;
 
     // Access to display mode:
-    void SetMode(Display::Mode mode, tColor Background = (tColor)ttSetup.configuredClrBackground);
+    void SetMode(Display::Mode mode, tColor clrBackground = (tColor)ttSetup.configuredClrBackground);
     inline void Delete()
         { if (display) { DELETENULL(display); } }
 
@@ -102,7 +102,7 @@ class cDisplay32BPP : public cDisplay {
     // No need for color mapping
     // Uses cPixmap instead of cBitmap
 public:
-    cDisplay32BPP(int x0, int y0, int width, int height, int leftFrame, int rightFrame, int topFrame, int bottomFrame);
+    cDisplay32BPP(int x0, int y0, int width, int height, int leftFrame, int rightFrame, int topFrame, int bottomFrame, tColor clrBackground);
 };
 
 
@@ -123,7 +123,7 @@ class cDisplay32BPPHalf : public cDisplay {
     // Needed to re-initialize osd
 
 public:
-    cDisplay32BPPHalf(int x0, int y0, int width, int height, int leftFrame, int rightFrame, int topFrame, int bottomFrame, bool upper, bool top);
+    cDisplay32BPPHalf(int x0, int y0, int width, int height, int leftFrame, int rightFrame, int topFrame, int bottomFrame, bool upper, bool top, tColor clrBackground);
     bool GetUpper() { return Upper; }
     void SetUpper(bool upper)
         { if (Upper!=upper) { Upper=upper; InitOSD(); } }

--- a/display.h
+++ b/display.h
@@ -126,9 +126,9 @@ public:
     cDisplay32BPPHalf(int x0, int y0, int width, int height, int leftFrame, int rightFrame, int topFrame, int bottomFrame, bool upper, bool top, tColor clrBackground);
     bool GetUpper() { return Upper; }
     void SetUpper(bool upper)
-        { if (Upper!=upper) { Upper=upper; InitOSD(); } }
+        { if (Upper!=upper) { Upper=upper; } }
     void SetTop(bool top)
-        { if (Top!=top) { Top=top; InitOSD(); } }
+        { if (Top!=top) { Top=top; } }
 protected:
     void InitOSD();
 };

--- a/displaybase.c
+++ b/displaybase.c
@@ -853,10 +853,10 @@ void cDisplay::ClearMessage() {
 
     // NEW, reverse calculation based on how DrawChar
     // map to character x/y
-    int x0 = (MessageX)            / (fontWidth  / 2) + leftFrame;
-    int y0 = (MessageY)            / (fontHeight / 2) + topFrame;
-    int x1 = (MessageX+MessageW-1) / (fontWidth  / 2) + leftFrame;
-    int y1 = (MessageY+MessageH-1) / (fontHeight / 2) + topFrame;
+    int x0 = (MessageX                - leftFrame) / (fontWidth  / 2);
+    int y0 = (MessageY                - topFrame ) / (fontHeight / 2);
+    int x1 = (MessageX + MessageW - 1 - leftFrame) / (fontWidth  / 2);
+    int y1 = (MessageY + MessageH - 1 - topFrame ) / (fontHeight / 2);
 
     DEBUG_OT_MSG("MX=%d MY=%d MW=%d MH=%d => x0=%d/y0=%d x1=%d/y1=%d", MessageX, MessageY, MessageW, MessageH, x0, y0, x1, y1);
 

--- a/displaybase.c
+++ b/displaybase.c
@@ -292,13 +292,14 @@ void cDisplay::RenderTeletextCode(unsigned char *PageCode) {
     DEBUG_OT_RENCLN("called with Boxed=%s Flags=0x%02x", BOOLTOTEXT(Boxed), Flags);
 
     if (!Boxed && (Flags&0x60)!=0) {
+        DEBUG_OT_RENCLN("Toggle Boxed: false->true");
         Boxed=true;
         CleanDisplay();
     } else if (Boxed && (Flags&0x60)==0) {
+        DEBUG_OT_RENCLN("Toggle Boxed: true->false");
         Boxed=false;
         CleanDisplay();
-    } else
-        CleanDisplay();
+    }
 
     if (memcmp(PageCode, "VTXV5", 5) != 0) {
         esyslog("osdteletext: cDisplay::RenderTeletextCode called with PageCode which is not starting with 'VTXV5' (not supported)");

--- a/displaybase.c
+++ b/displaybase.c
@@ -227,8 +227,6 @@ void cDisplay::SetZoom(enumZoom zoom) {
     // Re-initialize scaler to let zoom take effect
     InitScaler();
 
-    // Clear screen - mainly clear border
-    CleanDisplay();
     Dirty=true;
     DirtyAll=true;
 

--- a/displaybase.c
+++ b/displaybase.c
@@ -290,7 +290,7 @@ void cDisplay::RenderTeletextCode(unsigned char *PageCode) {
 
     cRenderPage::ReadTeletextHeader(PageCode);
 
-    DEBUG_OT_RENCLN("called");
+    DEBUG_OT_RENCLN("called with Boxed=%s Flags=0x%02x", BOOLTOTEXT(Boxed), Flags);
 
     if (!Boxed && (Flags&0x60)!=0) {
         Boxed=true;
@@ -314,7 +314,7 @@ void cDisplay::RenderTeletextCode(unsigned char *PageCode) {
 
 
 void cDisplay::DrawDisplay() {
-    DEBUG_OT_DD("called with Blinked=%d Concealed=%d Dirty=%s", Blinked, Concealed, (IsDirty() == true) ? "true" : "false");
+    DEBUG_OT_DD("called with Blinked=%d Concealed=%d Dirty=%s DirtyAll=%s IsDirty()=%s", Blinked, Concealed, BOOLTOTEXT(Dirty), BOOLTOTEXT(DirtyAll), BOOLTOTEXT(IsDirty()));
     int x,y;
 
     if (!IsDirty()) return; // nothing to do

--- a/displaybase.c
+++ b/displaybase.c
@@ -542,7 +542,7 @@ void cDisplay::DrawChar(int x, int y, cTeletextChar c) {
                 cache_outputHeight = outputHeight;
                 cache_OsdHeight    = cOsd::OsdHeight();
                 cache_Vshift       = (cache_txtVoffset * cache_outputHeight) / cache_OsdHeight;
-                dsyslog("osdteletext: DrawText vertical shift cache updated: txtVoffset=%d outputHeight=%d OsdHeight=%d => Vshift=%d", cache_txtVoffset, cache_outputHeight, cache_OsdHeight, cache_Vshift);
+                DEBUG_MASK_OT_DTXT("osdteletext: DrawText vertical shift cache updated: txtVoffset=%d outputHeight=%d OsdHeight=%d => Vshift=%d", cache_txtVoffset, cache_outputHeight, cache_OsdHeight, cache_Vshift);
             };
 
             if ((m_debugline >= 0) && (y == m_debugline)) {

--- a/displaybase.c
+++ b/displaybase.c
@@ -542,7 +542,7 @@ void cDisplay::DrawChar(int x, int y, cTeletextChar c) {
                 cache_outputHeight = outputHeight;
                 cache_OsdHeight    = cOsd::OsdHeight();
                 cache_Vshift       = (cache_txtVoffset * cache_outputHeight) / cache_OsdHeight;
-                DEBUG_MASK_OT_DTXT("osdteletext: DrawText vertical shift cache updated: txtVoffset=%d outputHeight=%d OsdHeight=%d => Vshift=%d", cache_txtVoffset, cache_outputHeight, cache_OsdHeight, cache_Vshift);
+                DEBUG_OT_DTXT("osdteletext: DrawText vertical shift cache updated: txtVoffset=%d outputHeight=%d OsdHeight=%d => Vshift=%d", cache_txtVoffset, cache_outputHeight, cache_OsdHeight, cache_Vshift);
             };
 
             if ((m_debugline >= 0) && (y == m_debugline)) {

--- a/displaybase.c
+++ b/displaybase.c
@@ -880,6 +880,9 @@ void cDisplay::ClearMessage() {
 	if TESTOORY(y0) y0 = 25 - 1;
 	if TESTOORY(y1) y1 = 25 - 1;
     }
+
+    HoldFlush();
+
     // DEBUG_OT_MSG("call MakeDirty with area x0=%d/y0=%d <-> x1=%d/y1=%d", x0, y0, x1, y1);
     for (int x=x0;x<=x1;x++) {
         for (int y=y0;y<=y1;y++) {
@@ -890,7 +893,7 @@ void cDisplay::ClearMessage() {
     MessageW=0;
     MessageH=0;
 
-    Flush();
+    ReleaseFlush();
 }
 
 // vim: ts=4 sw=4 et

--- a/displaybase.c
+++ b/displaybase.c
@@ -31,7 +31,6 @@ cDisplay::cDisplay(int width, int height)
       osd(NULL),
       outputWidth(0), outputHeight(0),
       leftFrame(0), rightFrame(0), topFrame(0), bottomFrame(0),
-      OffsetX(0), OffsetY(0),
       MessageFont(cFont::GetFont(fontSml)), MessageX(0), MessageY(0),
       MessageW(0), MessageH(0),
       TXTFont(0), TXTDblWFont(0), TXTDblHFont(0), TXTDblHWFont(0), TXTHlfHFont(0)
@@ -124,15 +123,12 @@ void cDisplay::InitScaler() {
 
     int height=Height-6;
     // int width=Width-6; // EOL: no longer used
-    OffsetX=3;
-    OffsetY=3;
 
     switch (Zoom) {
         case Zoom_Upper:
             height=height*2;
             break;
         case Zoom_Lower:
-            OffsetY=OffsetY-height;
             height=height*2;
             break;
         default:;
@@ -845,9 +841,9 @@ void cDisplay::DrawMessage(const char *txt, const enumTeletextColor cFrame, cons
     if (fg==bg) bg=GetColorRGBAlternate(cBackground,0);
 
     // Draw framed box (2 outer pixel always background)
-    osd->DrawRectangle(x         ,y         ,x+w-1       ,y+h-1       ,bg); // outer rectangle
-    osd->DrawRectangle(x+2       ,y+2       ,x+w-1-2     ,y+h-1-2     ,fr); // inner rectangle
-    osd->DrawRectangle(x+border  ,y+border  ,x+w-border-1,y+h-border-1,bg); // background for text
+    osd->DrawRectangle(x           , y           , x+w-1         , y+h-1         , bg); // outer rectangle
+    osd->DrawRectangle(x+(border/2), y+(border/2), x+w-1-border/2, y+h-1-border/2, fr); // inner rectangle
+    osd->DrawRectangle(x+border    , y+border    , x+w-1-border  , y+h-1-border  , bg); // background for text
 
     // Draw text
     osd->DrawText(x+2*border, y+2*border,txt, fg, bg, MessageFont, w - 4*border, h - 4*border);
@@ -858,7 +854,7 @@ void cDisplay::DrawMessage(const char *txt, const enumTeletextColor cFrame, cons
     MessageX=x;
     MessageY=y;
 
-    DEBUG_OT_MSG("MX=%d MY=%d MW=%d MH=%d OX=%d OY=%d OW=%d OH=%d", MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, outputWidth, outputHeight);
+    DEBUG_OT_MSG("MX=%d MY=%d MW=%d MH=%d OW=%d OH=%d", MessageX, MessageY, MessageW, MessageH, outputWidth, outputHeight);
 
     // And flush all changes
     ReleaseFlush();
@@ -870,18 +866,18 @@ void cDisplay::ClearMessage() {
 
     // NEW, reverse calculation based on how DrawChar
     // map to character x/y
-    int x0 = (MessageX - OffsetX)          / (fontWidth  / 2) + leftFrame;
-    int y0 = (MessageY - OffsetY)          / (fontHeight / 2) + topFrame;
-    int x1 = (MessageX+MessageW-1-OffsetX) / (fontWidth  / 2) + leftFrame;
-    int y1 = (MessageY+MessageH-1-OffsetY) / (fontHeight / 2) + topFrame;
+    int x0 = (MessageX)            / (fontWidth  / 2) + leftFrame;
+    int y0 = (MessageY)            / (fontHeight / 2) + topFrame;
+    int x1 = (MessageX+MessageW-1) / (fontWidth  / 2) + leftFrame;
+    int y1 = (MessageY+MessageH-1) / (fontHeight / 2) + topFrame;
 
-    DEBUG_OT_MSG("MX=%d MY=%d MW=%d MH=%d OX=%d OY=%d => x0=%d/y0=%d x1=%d/y1=%d", MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY, x0, y0, x1, y1);
+    DEBUG_OT_MSG("MX=%d MY=%d MW=%d MH=%d => x0=%d/y0=%d x1=%d/y1=%d", MessageX, MessageY, MessageW, MessageH, x0, y0, x1, y1);
 
 #define TESTOORX(X) (X < 0 || X >= 40)
 #define TESTOORY(Y) (Y < 0 || Y >= 25)
     if ( TESTOORX(x0) || TESTOORX(x1) || TESTOORY(y0) || TESTOORY(y1) ) {
         // something out-of-range
-	    esyslog("osdteletext: %s out-of-range detected(crop) MessageX=%d MessageY=%d MessageW=%d MessageH=%d OffsetX=%d OffsetY=%d => x0=%d%s y0=%d%s x1=%d%s y1=%d%s", __FUNCTION__, MessageX, MessageY, MessageW, MessageH, OffsetX, OffsetY,
+	    esyslog("osdteletext: %s out-of-range detected(crop) MessageX=%d MessageY=%d MessageW=%d MessageH=%d => x0=%d%s y0=%d%s x1=%d%s y1=%d%s", __FUNCTION__, MessageX, MessageY, MessageW, MessageH,
 		x0, TESTOORX(x0) ? "!" : "",
 		y0, TESTOORY(y0) ? "!" : "",
 		x1, TESTOORX(x1) ? "!" : "",

--- a/displaybase.c
+++ b/displaybase.c
@@ -118,22 +118,6 @@ void cDisplay::InitScaler() {
     // Set up the scaling factors. Also do zoom mode by
     // scaling differently.
 
-    // outputScaleX = (double)outputWidth/480.0; // EOL: no longer used
-    // outputScaleY = (double)outputHeight / (((ttSetup.lineMode24 == true) ? 24 : 25) * 10.0); // EOL: no longer used
-
-    int height=Height-6;
-    // int width=Width-6; // EOL: no longer used
-
-    switch (Zoom) {
-        case Zoom_Upper:
-            height=height*2;
-            break;
-        case Zoom_Lower:
-            height=height*2;
-            break;
-        default:;
-    }
-
     fontWidth = (outputWidth * 2 / 40) & 0xfffe;
     if (Zoom == Zoom_Off) {
         fontHeight = (outputHeight * 2 / ((ttSetup.lineMode24 == true) ? 24 : 25)) & 0xfffe;

--- a/displaybase.c
+++ b/displaybase.c
@@ -28,6 +28,7 @@ cDisplay::cDisplay(int width, int height)
     : Zoom(Zoom_Off), Concealed(true), Blinked(false), FlushLock(0),
       Boxed(false), Width(width), Height(height), Background(clrGray50),
       Paused(false),
+      PageIdDisplayedEver(false),
       osd(NULL),
       outputWidth(0), outputHeight(0),
       leftFrame(0), rightFrame(0), topFrame(0), bottomFrame(0),
@@ -709,7 +710,7 @@ void cDisplay::DrawPageId(const char *text, const enumTeletextColor cText) {
 
     DEBUG_OT_DRPI("called with text='%s' text_last='%s' Boxed=%d HasConceal=%d GetConceal=%d", text, text_last, Boxed, HasConceal(), GetConceal());
 
-    if (! GetPaused() && Boxed && (strcmp(text, text_last) == 0)) {
+    if (! GetPaused() && Boxed && PageIdDisplayedEver && (strcmp(text, text_last) == 0)) {
         // don't draw PageId a 2nd time on boxed pages
         for (int i = 0; i < 8; i++) {
             c.SetFGColor(ttcTransparent);
@@ -722,6 +723,7 @@ void cDisplay::DrawPageId(const char *text, const enumTeletextColor cText) {
 
     DrawText(0,0,text,8, cText);
     strncpy(text_last, text, sizeof(text_last) - 1);
+    PageIdDisplayedEver = true;
 
     if (HasConceal()) {
         c.SetBGColor(ttcBlack);

--- a/displaybase.c
+++ b/displaybase.c
@@ -309,7 +309,7 @@ void cDisplay::RenderTeletextCode(unsigned char *PageCode) {
 
 
 void cDisplay::DrawDisplay() {
-    DEBUG_OT_DD("called with Blinked=%d Concealed=%d", Blinked, Concealed);
+    DEBUG_OT_DD("called with Blinked=%d Concealed=%d Dirty=%s", Blinked, Concealed, (IsDirty() == true) ? "true" : "false");
     int x,y;
     int cnt=0;
 

--- a/displaybase.c
+++ b/displaybase.c
@@ -227,7 +227,7 @@ void cDisplay::SetZoom(enumZoom zoom) {
     InitScaler();
 
     // Clear screen - mainly clear border
-    // CleanDisplay(); // called later after SetBackgroundColor
+    CleanDisplay();
     Dirty=true;
     DirtyAll=true;
 
@@ -242,14 +242,19 @@ void cDisplay::SetBackgroundColor(tColor c) {
 }
 
 void cDisplay::CleanDisplay() {
-    enumTeletextColor bgc=(Boxed)?(ttcTransparent):(ttcBlack);
+    tColor bgc;
+
     if (!osd) return;
 
-    DEBUG_OT_DBFC("called: outputWidth=%d outputHeight=%d boxed=%d color=0x%08x bgc=%d", outputWidth, outputHeight, Boxed, GetColorRGB(bgc,0), bgc);
-    if (m_debugmask & DEBUG_MASK_OT_ACT_OSD_BACK_RED)
-        osd->DrawRectangle(0, 0, outputWidth - 1 + leftFrame + rightFrame, outputHeight - 1 + topFrame + bottomFrame, GetColorRGB(ttcRed,0));
+    if (Boxed)
+        bgc = GetColorRGB(ttcTransparent,0);
+    else if (m_debugmask & DEBUG_MASK_OT_ACT_OSD_BACK_RED)
+        bgc = GetColorRGB(ttcRed,0);
     else
-        osd->DrawRectangle(0, 0, outputWidth - 1 + leftFrame + rightFrame, outputHeight - 1 + topFrame + bottomFrame, GetColorRGB(bgc,0));
+        bgc = Background;
+
+    DEBUG_OT_RENCLN("called: outputWidth=%d outputHeight=%d boxed=%s color=0x%08x", outputWidth, outputHeight, BOOLTOTEXT(Boxed), bgc);
+    osd->DrawRectangle(0, 0, outputWidth - 1 + leftFrame + rightFrame, outputHeight - 1 + topFrame + bottomFrame, bgc);
 
     // repaint all
     Dirty=true;

--- a/displaybase.c
+++ b/displaybase.c
@@ -311,7 +311,6 @@ void cDisplay::RenderTeletextCode(unsigned char *PageCode) {
 void cDisplay::DrawDisplay() {
     DEBUG_OT_DD("called with Blinked=%d Concealed=%d Dirty=%s", Blinked, Concealed, (IsDirty() == true) ? "true" : "false");
     int x,y;
-    int cnt=0;
 
     if (!IsDirty()) return; // nothing to do
 
@@ -319,7 +318,6 @@ void cDisplay::DrawDisplay() {
         for (x=0;x<40;x++) {
             if (IsDirty(x,y)) {
                 // Need to draw char to osd
-                cnt++;
                 cTeletextChar c=Page[x][y];
                 c.SetDirty(false);
                 if ((Blinked && c.GetBlink()) || (Concealed && c.GetConceal())) {

--- a/displaybase.c
+++ b/displaybase.c
@@ -290,7 +290,7 @@ void cDisplay::RenderTeletextCode(unsigned char *PageCode) {
 
     cRenderPage::ReadTeletextHeader(PageCode);
 
-    DEBUG_OT_DBFC("called");
+    DEBUG_OT_RENCLN("called");
 
     if (!Boxed && (Flags&0x60)!=0) {
         Boxed=true;
@@ -841,7 +841,7 @@ void cDisplay::DrawMessage(const char *txt, const enumTeletextColor cFrame, cons
     MessageX=x;
     MessageY=y;
 
-    DEBUG_OT_MSG("MX=%d MY=%d MW=%d MH=%d OW=%d OH=%d", MessageX, MessageY, MessageW, MessageH, outputWidth, outputHeight);
+    DEBUG_OT_MSG("MX=%d MY=%d MW=%d MH=%d OW=%d OH=%d text='%s'", MessageX, MessageY, MessageW, MessageH, outputWidth, outputHeight, txt);
 
     // And flush all changes
     ReleaseFlush();

--- a/displaybase.h
+++ b/displaybase.h
@@ -63,6 +63,9 @@ protected:
     bool Paused;
     // Paused internal state
 
+    bool PageIdDisplayedEver;
+    // Flag whether the PageId was ever displayed so far
+
     cOsd *osd;
     // The osd object. If creation fails, may be NULL
 

--- a/displaybase.h
+++ b/displaybase.h
@@ -73,9 +73,6 @@ protected:
     int leftFrame, rightFrame, topFrame, bottomFrame;
     // frame border
 
-    int OffsetX,OffsetY;
-    // Virtual coordinate system, see InitScaler
-
     const cFont *MessageFont;
     int MessageX,MessageY,MessageW,MessageH;
 
@@ -140,8 +137,6 @@ protected:
 
     // ScaleX,ScaleY represent the (virtual) width and height of a
     // physical OSD pixel.
-    // OffsetX,OffsetY default to 3,3 to represent the border offset,
-    // but may be used differently.
 
 public:
     bool GetBlink() { return Blinked; }
@@ -247,7 +242,6 @@ private:
 };
 
 
-
 inline void cDisplay::cBox::SetToCharacter(int x, int y) {
     // Virtual box area of a character
     XMin=(x*12)<<16;
@@ -255,28 +249,5 @@ inline void cDisplay::cBox::SetToCharacter(int x, int y) {
     XMax=XMin+(12<<16)-1;
     YMax=YMin+(10<<16)-1;
 }
-
-/*
-inline void cDisplay::cVirtualCoordinate::VirtualToPixel(cDisplay *Display, int x, int y) {
-    // Map virtual coordinate to OSD pixel
-    OsdX=x/Display->ScaleX+Display->OffsetX;
-    OsdY=y/Display->ScaleY+Display->OffsetY;
-
-    // map OSD pixel back to virtual coordinate, use center of pixel
-    VirtX=(OsdX-Display->OffsetX)*Display->ScaleX+Display->ScaleX/2;
-    VirtY=(OsdY-Display->OffsetY)*Display->ScaleY+Display->ScaleY/2;
-}
-
-inline void cDisplay::cVirtualCoordinate::IncPixelX(cDisplay *Display) {
-    // Move one OSD pixel
-    OsdX++;
-    VirtX+=Display->ScaleX;
-}
-inline void cDisplay::cVirtualCoordinate::IncPixelY(cDisplay *Display) {
-    // Move one OSD pixel
-    OsdY++;
-    VirtY+=Display->ScaleY;
-}
-*/
 
 #endif

--- a/logging.h
+++ b/logging.h
@@ -9,6 +9,8 @@ extern unsigned int m_debugpage;
 extern unsigned int m_debugpsub;
 extern          int m_debugline;
 
+#define BOOLTOTEXT(var)	 ((var == true) ? "true" : "false")
+
 #define DEBUG_MASK_OT		0x00000001	// general
 #define DEBUG_MASK_OT_CACHE	0x00000002	// Caching System
 #define DEBUG_MASK_OT_KNONE	0x00000010	// Knone action
@@ -28,6 +30,7 @@ extern          int m_debugline;
 #define DEBUG_MASK_OT_BOXED	0x00400000	// BoxedOut
 #define DEBUG_MASK_OT_DTXT 	0x00800000	// DrawText
 #define DEBUG_MASK_OT_TXTRDT	0x01000000	// Text Rendering triplet
+#define DEBUG_MASK_OT_RENCLN	0x02000000	// Render/Clean
 #define DEBUG_MASK_OT_TXTRCVD	0x04000000	// Text Receiver dump to stdout (particular page only, see code)
 #define DEBUG_MASK_OT_TXTRD	0x08000000	// Text Rendering dump to stdout
 
@@ -57,6 +60,7 @@ extern          int m_debugline;
 #define DEBUG_OT_DTXT   if (m_debugmask & DEBUG_MASK_OT_DTXT )  dsyslog_ot
 #define DEBUG_OT_CACHE  if (m_debugmask & DEBUG_MASK_OT_CACHE)  dsyslog_ot
 #define DEBUG_OT_TXTRDT if (m_debugmask & DEBUG_MASK_OT_TXTRDT) dsyslog_ot
+#define DEBUG_OT_RENCLN if (m_debugmask & DEBUG_MASK_OT_RENCLN) dsyslog_ot
 #define DEBUG_OT_TXTRCVD if (m_debugmask & DEBUG_MASK_OT_TXTRCVD) dsyslog_ot
 #define DEBUG_OT_TXTRD  if (m_debugmask & DEBUG_MASK_OT_TXTRD) dsyslog_ot
 

--- a/menu.c
+++ b/menu.c
@@ -149,8 +149,8 @@ eOSState TeletextBrowser::ProcessKey(eKeys Key) {
 
    if (Key != kNone)
       lastActivity = time(NULL);
-   
-   DEBUG_OT_KEYS("called with Key=%d", Key);
+
+   if (Key != kNone) DEBUG_OT_KEYS("called with Key=%d", Key);
 
    switch (Key) {
       case k1: SetNumber(1);break;
@@ -341,8 +341,10 @@ eOSState TeletextBrowser::ProcessKey(eKeys Key) {
       modeR = Display::mode; // remember mode
       if (ttSetup.configuredClrBackground != bgcSetup) {
          bgcR = ttSetup.configuredClrBackground; // color was changed during config
+         DEBUG_OT_KEYS("osdteletext: recreate display with remembered mode=%d zoom=%d and setup configured bgc=%08x", modeR, zoomR, bgcR);
       } else {
          bgcR = Display::GetBackgroundColor(); // remember color
+         DEBUG_OT_KEYS("osdteletext: recreate display with remembered mode=%d zoom=%d bgc=%08x", modeR, zoomR, bgcR);
       };
       Display::Delete();
       Display::SetMode(modeR, bgcR); // new with remembered mode and backgroud color

--- a/menu.c
+++ b/menu.c
@@ -33,7 +33,6 @@
 
 using namespace std;
    
-int Stretch = true;
 typedef map<int,int> IntMap;
 IntMap channelPageMap;
 

--- a/menu.c
+++ b/menu.c
@@ -36,7 +36,6 @@ using namespace std;
 int Stretch = true;
 typedef map<int,int> IntMap;
 IntMap channelPageMap;
-tColor clrBackground = (tColor) ttSetup.configuredClrBackground; // default
 
 //static variables
 int TeletextBrowser::currentPage=0x100; //Believe it or not, the teletext numbers are somehow hexadecimal
@@ -46,6 +45,8 @@ cChannel TeletextBrowser::channelClass;
 int TeletextBrowser::currentChannelNumber=0;
 int TeletextBrowser::liveChannelNumber=0;
 TeletextBrowser* TeletextBrowser::self=0;
+tColor clrBackground;
+bool clrBackgroundInit = false;
 
 eTeletextActionConfig configMode = NotActive;
 
@@ -56,8 +57,12 @@ TeletextBrowser::TeletextBrowser(cTxtStatus *txtSt,Storage *s)
     previousSubPage(currentSubPage), pageBeforeNumberInput(currentPage),
     lastActivity(time(NULL)), inactivityTimeout(-1), storage(s)
 {
+   if (!clrBackgroundInit) {
+      clrBackground = (tColor) ttSetup.configuredClrBackground; // default
+      clrBackgroundInit = true;
+   };
+
    self=this;
-   clrBackground = (tColor) ttSetup.configuredClrBackground; // default
 
    //if (txtStatus)
     //  txtStatus->ForceReceiving(true);

--- a/menu.c
+++ b/menu.c
@@ -36,6 +36,7 @@ using namespace std;
 int Stretch = true;
 typedef map<int,int> IntMap;
 IntMap channelPageMap;
+tColor clrBackground = (tColor) ttSetup.configuredClrBackground; // default
 
 //static variables
 int TeletextBrowser::currentPage=0x100; //Believe it or not, the teletext numbers are somehow hexadecimal
@@ -56,6 +57,8 @@ TeletextBrowser::TeletextBrowser(cTxtStatus *txtSt,Storage *s)
     lastActivity(time(NULL)), inactivityTimeout(-1), storage(s)
 {
    self=this;
+   clrBackground = (tColor) ttSetup.configuredClrBackground; // default
+
    //if (txtStatus)
     //  txtStatus->ForceReceiving(true);
 }
@@ -73,7 +76,7 @@ TeletextBrowser::~TeletextBrowser() {
 }
 
 void TeletextBrowser::Show(void) {
-    Display::SetMode(Display::mode);
+    Display::SetMode(Display::mode, clrBackground);
     ShowPage();
 }
 
@@ -420,7 +423,6 @@ bool TeletextBrowser::ExecuteActionConfig(eTeletextActionConfig e, int delta) {
 void TeletextBrowser::ExecuteAction(eTeletextAction e) {
    cDisplay::enumZoom zoomR;
    Display::Mode modeR;
-   tColor bgcR;
 
    switch (e) {
       case Zoom:
@@ -444,7 +446,7 @@ void TeletextBrowser::ExecuteAction(eTeletextAction e) {
          break;
 
       case HalfPage:
-         DEBUG_OT_KEYS("key action: 'Half Page' Display::mode=%d", Display::mode);
+         DEBUG_OT_KEYS("key action: 'Half Page' Display::mode=%d clrBackground=%08x", Display::mode, clrBackground);
          if (selectingChannel) {
              selectingChannel=false;
              Display::ClearMessage();
@@ -452,19 +454,19 @@ void TeletextBrowser::ExecuteAction(eTeletextAction e) {
                   
          switch (Display::mode) {
             case Display::HalfUpper:
-               Display::SetMode(Display::HalfLower, Display::GetBackgroundColor());
+               Display::SetMode(Display::HalfLower, clrBackground);
                break;
             case Display::HalfLower:
-               Display::SetMode(Display::HalfUpperTop, Display::GetBackgroundColor());
+               Display::SetMode(Display::HalfUpperTop, clrBackground);
                break;
             case Display::HalfUpperTop:
-               Display::SetMode(Display::HalfLowerTop, Display::GetBackgroundColor());
+               Display::SetMode(Display::HalfLowerTop, clrBackground);
                break;
             case Display::HalfLowerTop:
-               Display::SetMode(Display::Full, Display::GetBackgroundColor());
+               Display::SetMode(Display::Full, clrBackground);
                break;
             case Display::Full:
-               Display::SetMode(Display::HalfUpper, Display::GetBackgroundColor());
+               Display::SetMode(Display::HalfUpper, clrBackground);
                break;
             }
             ShowPage();
@@ -507,9 +509,8 @@ void TeletextBrowser::ExecuteAction(eTeletextAction e) {
          };
          zoomR = Display::GetZoom(); // remember zoom
          modeR = Display::mode; // remember mode
-         bgcR = Display::GetBackgroundColor(); // remember color
          Display::Delete();
-         Display::SetMode(modeR, bgcR); // new with remembered mode and background color
+         Display::SetMode(modeR, clrBackground); // new with remembered mode and background color
          Display::SetZoom(zoomR); // apply remembered zoom
          ShowPage();
          break;
@@ -582,20 +583,22 @@ void TeletextBrowser::ExecuteAction(eTeletextAction e) {
 void TeletextBrowser::ChangeBackground()
 {
    tColor clrConfig = (tColor)ttSetup.configuredClrBackground;
-   tColor clrCurrent = Display::GetBackgroundColor();
+   tColor clrCurrent = clrBackground;
 
    if (clrCurrent == clrConfig)
       if (clrConfig == clrTransparent)
-         Display::SetBackgroundColor(clrBlack);
+         clrBackground = clrBlack;
       else
-         Display::SetBackgroundColor(clrTransparent);
+         clrBackground = clrTransparent;
    else if (clrCurrent == clrBlack)
       if (clrConfig == clrBlack)
-         Display::SetBackgroundColor(clrTransparent);
+         clrBackground = clrTransparent;
       else
-         Display::SetBackgroundColor(clrConfig);
+         clrBackground = clrConfig;
    else // clrCurrent == clrTransparent
-      Display::SetBackgroundColor(clrBlack);
+      clrBackground = clrBlack;
+
+   Display::SetBackgroundColor(clrBackground);
 }
 
 eTeletextAction TeletextBrowser::TranslateKey(eKeys Key) {

--- a/menu.h
+++ b/menu.h
@@ -21,8 +21,6 @@
 #include "txtrecv.h"
 #include "setup.h"
 
-extern int Stretch;
-
 class TeletextBrowser : public cOsdObject {
 public:
    TeletextBrowser(cTxtStatus *txtSt,Storage *s);

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -363,7 +363,6 @@ bool cPluginTeletextosd::SetupParse(const char *Name, const char *Value)
 {
   initTexts();
   // Parse your own setup parameters and store their values.
-  //Stretch=true;
   if (!strcasecmp(Name, "configuredClrBackground")) ttSetup.configuredClrBackground=( ((unsigned int)atoi(Value)) << 24);
   else if (!strcasecmp(Name, "showClock")) ttSetup.showClock=atoi(Value);
      //currently not used

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -32,7 +32,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "1.9.9.dev.7";
+static const char *VERSION        = "1.9.9.dev.8";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 


### PR DESCRIPTION
- many fixes found during regression tests related to MessageBox, too often CleanDisplay calls, ...
- display PageId always in case OSD was restarted (useful e.g. for subtitle pages)
- selected background color kept on OSD restart
