### PR TITLE
1.9.9.dev.9 regression

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,8 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
+2021-04-09:
+- [pbiering] clear teletext page on channel switch
+
 2021-04-08:
 - [pbiering] many fixes found during regression tests related to MessageBox, too often CleanDisplay calls, ...
 - [pbiering] display PageId always in case OSD was restarted (useful e.g. for subtitle pages)

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ DEFINES += -DPLUGIN_NAME_I18N='"$(PLUGIN)"'
 
 ### The object files (add further files here):
 
-OBJS = $(PLUGIN).o menu.o txtfont.o txtrecv.o txtrender.o displaybase.o display.o storage.o legacystorage.o packedstorage.o rootdir.o
+OBJS = $(PLUGIN).o menu.o txtfont.o txtrecv.o txtrender.o displaybase.o display.o storage.o legacystorage.o packedstorage.o rootdir.o setup.o
 
 ### The main target:
 

--- a/display.h
+++ b/display.h
@@ -94,6 +94,8 @@ namespace Display {
         { if (display) display->DrawMessage(txt, cFrame, cText, cBackground); }
     inline void ClearMessage()
         { if (display) display->ClearMessage(); }
+    inline void ClearPage()
+        { if (display) display->ClearPage(); }
 }
 
 

--- a/displaybase.c
+++ b/displaybase.c
@@ -701,6 +701,23 @@ void cDisplay::DrawText(int x, int y, const char *text, int len, const enumTelet
     Flush();
 }
 
+
+void cDisplay::ClearPage(void) {
+    // Clear Teletext Page on OSD
+    cTeletextChar c;
+    c.SetFGColor(ttcTransparent); // no char
+    c.SetBGColor(ttcBlack); // pass selected background
+    c.SetChar(' ');
+
+    // reset 40x24 area with space
+    for (int y = 0; y < 24; y++)
+        for (int x = 0; x < 40; x++)
+            SetChar(x, y, c);
+
+    return;
+};
+
+
 void cDisplay::DrawPageId(const char *text, const enumTeletextColor cText) {
     // Draw Page ID string to OSD
     static char text_last[9] = ""; // remember

--- a/displaybase.c
+++ b/displaybase.c
@@ -277,6 +277,7 @@ tColor cDisplay::GetColorRGB(enumTeletextColor ttc, int Area) {
 }
 
 tColor cDisplay::GetColorRGBAlternate(enumTeletextColor ttc, int Area) {
+    // TODO implement ??
     return GetColorRGB(ttc,Area);
 }
 

--- a/displaybase.c
+++ b/displaybase.c
@@ -812,7 +812,7 @@ void cDisplay::DrawClock() {
 }
 
 void cDisplay::DrawMessage(const char *txt, const enumTeletextColor cFrame, const enumTeletextColor cText, const enumTeletextColor cBackground) {
-    int border=4; // minimum
+    int border=6; // minimum
     if (outputWidth > 720) {
         // increase border
         border = ((border * outputWidth) / 720) & 0xfffe; // always even number

--- a/displaybase.h
+++ b/displaybase.h
@@ -239,6 +239,9 @@ public:
     void ClearMessage();
     // Remove message box and redraw hidden content
 
+    void ClearPage(void);
+    // Clear Teletext Page on OSD
+
 private:
     cFont *GetFont(const char *name, int index, int height, int width);
     std::string GetFontFootprint(const char *name);

--- a/menu.c
+++ b/menu.c
@@ -416,6 +416,7 @@ bool TeletextBrowser::ExecuteActionConfig(eTeletextActionConfig e, int delta) {
          DEBUG_OT_KEYS("key action: 'Config->BackTrans' BackTransVal=%d BackTransMin=%d BackTransMax=%d delta=%d", BackTransVal, BackTransMin, BackTransMax, delta * 8);
          COND_ADJ_VALUE(BackTransVal, BackTransMin, BackTransMax, delta * 8);
          ttSetup.configuredClrBackground = ((uint32_t) BackTransVal) << 24;
+         clrBackground = ttSetup.configuredClrBackground;
          break;
 
       default:

--- a/menu.c
+++ b/menu.c
@@ -527,7 +527,7 @@ void TeletextBrowser::ExecuteAction(eTeletextAction e) {
          if (ttSetup.lineMode24) {
             // config mode is only supported in 25-line mode
             Display::ClearMessage();
-            Display::DrawMessage(tr("*** Config mode is not supported in 24-line mode ***"), ttcRed);
+            Display::DrawMessage(tr("*** Config mode is not supported in 24-line mode ***"), ttcYellow);
             sleep(1);
             break;
          };

--- a/menu.c
+++ b/menu.c
@@ -129,6 +129,7 @@ void TeletextBrowser::ChannelSwitched(int ChannelNumber, const bool live) {
    }
 
    char str[80];
+   Display::ClearPage();
    if (liveChannelNumber != currentChannelNumber)
       snprintf(str, sizeof(str), "%s %s: %s", tr("Switch to cached"), tr("Channel"), channelClass.Name());
    else if (live)

--- a/menu.c
+++ b/menu.c
@@ -194,6 +194,7 @@ eOSState TeletextBrowser::ProcessKey(eKeys Key) {
                else {
                   needClearMessage=true;
                   Display::DrawMessage(trVDR("*** Invalid Channel ***"), ttcRed);
+                  sleep(1);
                }
             } else {
                ChannelSwitched(liveChannelNumber);
@@ -525,6 +526,7 @@ void TeletextBrowser::ExecuteAction(eTeletextAction e) {
             // config mode is only supported in 25-line mode
             Display::ClearMessage();
             Display::DrawMessage(tr("*** Config mode is not supported in 24-line mode ***"), ttcRed);
+            sleep(1);
             break;
          };
          switch(configMode) {

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -32,7 +32,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "1.9.9.dev.8";
+static const char *VERSION        = "1.9.9.dev.9";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 

--- a/setup.c
+++ b/setup.c
@@ -1,0 +1,56 @@
+/*************************************************************** -*- c++ -*-
+ *       Copyright (c) < 2021    by TODO                                   *
+ *       Copyright (c) 2021      by Peter Bieringer (extenions)            *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "setup.h"
+
+const char *st_modes[] =
+{
+      tr("Zoom"),
+      tr("Half page"),
+      tr("Change channel"),
+      tr("Switch background"),
+      //tr("Suspend receiving"),
+      tr("Config"),
+      tr("24-LineMode"),
+      tr("Answer"),
+      tr("Pause"),
+      tr("Jump to..."),
+};
+
+const char *st_modesFooter[] =
+{
+      // 1:1 relation to *st_modes[] from above and maximum 10 chars used in line25 footer //
+      tr("Zoom"),
+      tr("Half Page"),
+      tr("ChangeChan"),
+      tr("SwitchBack"),
+      //tr("SuspendRecv"),
+      tr("Config"),
+      tr("24LineMode"),
+      tr("Answer"),
+      tr("Pause"),
+      tr("Jump to..."),
+};
+
+const char *config_modes[] =
+{
+   // maximum 9 chars, 10th is -/+
+   tr("Left"),
+   tr("Top"),
+   tr("Width"),
+   tr("Height"),
+   tr("Frame"),
+   tr("Text Font"),
+   tr("TxVoffset"),
+   tr("BackTrans"),
+};
+
+// vim: ts=3 sw=3 et

--- a/setup.h
+++ b/setup.h
@@ -57,47 +57,12 @@ enum eTeletextActionValueType {
    None,
 };
 
-static const char *st_modes[] =
-{
-      tr("Zoom"),
-      tr("Half page"),
-      tr("Change channel"),
-      tr("Switch background"),
-      //tr("Suspend receiving"),
-      tr("Config"),
-      tr("24-LineMode"),
-      tr("Answer"),
-      tr("Pause"),
-      tr("Jump to..."),
-};
 
-static const char *st_modesFooter[] =
-{
-      // 1:1 relation to *st_modes[] from above and maximum 10 chars used in line25 footer //
-      tr("Zoom"),
-      tr("Half Page"),
-      tr("ChangeChan"),
-      tr("SwitchBack"),
-      //tr("SuspendRecv"),
-      tr("Config"),
-      tr("24LineMode"),
-      tr("Answer"),
-      tr("Pause"),
-      tr("Jump to..."),
-};
+// values stored in setup.c:
+extern const char *st_modes[];
+extern const char *st_modesFooter[];
+extern const char *config_modes[];
 
-static const char *config_modes[] =
-{
-   // maximum 9 chars, 10th is -/+
-   tr("Left"),
-   tr("Top"),
-   tr("Width"),
-   tr("Height"),
-   tr("Frame"),
-   tr("Text Font"),
-   tr("TxVoffset"),
-   tr("BackTrans"),
-};
 
 enum ActionKeys {
    // keep in sync: static const ActionKeyName st_actionKeyNames in osdteletext.c


### PR DESCRIPTION
- clear teletext page on channel switch
- improve code related to static config text values
