### PR TITLE
2.0.1 regression

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,10 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
+2021-04-11: version 2.0.1
+- [pbiering] fix warnings reported by clang
+- [pbiering] display channel switch message only in case OSD is active
+- [pbiering] fix G0 character without diacritical mark
+
 2021-04-11: version 2.0.0
 - [pbiering] additional fixes found during regression tests related to translations and others
 

--- a/HISTORY
+++ b/HISTORY
@@ -4,6 +4,7 @@ VDR Plugin 'osdteletext' Revision History
 - [pbiering] fix warnings reported by clang
 - [pbiering] display channel switch message only in case OSD is active
 - [pbiering] fix G0 character without diacritical mark
+- [pbiering] bring storage system "packed" back to default
 
 2021-04-11: version 2.0.0
 - [pbiering] additional fixes found during regression tests related to translations and others

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ PLUGIN = osdteletext
 
 VERSION = $(shell grep 'static const char \*VERSION *=' $(PLUGIN).c | awk '{ print $$6 }' | sed -e 's/[";]//g')
 
+### switch compiler
+ifeq ($(CLANG), 1)
+    CC="clang"
+    CXX="clang++"
+endif
+
 ### The directory environment:
 
 # Use package data if installed...otherwise assume we're under the VDR source directory:
@@ -26,6 +32,28 @@ TMPDIR ?= /tmp
 
 export CFLAGS   = $(call PKGCFG,cflags)
 export CXXFLAGS = $(call PKGCFG,cxxflags)
+
+ifeq ($(CLANG), 1)
+    $(info ORG CFLAGS=$(CFLAGS))
+    $(info ORG CXXFLAGS=$(CXXFLAGS))
+    # remove not supported options (at least Fedora 33)
+    CFLAGS_PKGCFG   = $(call PKGCFG,cflags)
+    CXXFLAGS_PKGCFG = $(call PKGCFG,cxxflags)
+    CFLAGS_1 = $(subst -ffat-lto-objects,,$(CFLAGS_PKGCFG))
+    CXXFLAGS_1 = $(subst -ffat-lto-objects,,$(CXXFLAGS_PKGCFG))
+    CFLAGS_2 = $(subst -flto=auto,,$(CFLAGS_1))
+    CXXFLAGS_2 = $(subst -flto=auto,,$(CXXFLAGS_1))
+    CFLAGS_3 = $(subst -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1,,$(CFLAGS_2))
+    CXXFLAGS_3 = $(subst -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1,,$(CXXFLAGS_2))
+    CFLAGS_4 = $(subst -specs=/usr/lib/rpm/redhat/redhat-hardened-ld,,$(CFLAGS_3))
+    CXXFLAGS_4 = $(subst -specs=/usr/lib/rpm/redhat/redhat-hardened-ld,,$(CXXFLAGS_3))
+    CFLAGS_5 = $(subst -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1,,$(CFLAGS_4))
+    CXXFLAGS_5 = $(subst -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1,,$(CXXFLAGS_4))
+    export CFLAGS   = $(CFLAGS_5)
+    export CXXFLAGS = $(CXXFLAGS_5)
+    $(info MOD CFLAGS=$(CFLAGS))
+    $(info MOD CXXFLAGS=$(CXXFLAGS))
+endif
 
 ### The version number of VDR's plugin API:
 

--- a/displaybase.c
+++ b/displaybase.c
@@ -675,7 +675,7 @@ void cDisplay::DrawTextExtended(const int x, const int y, const char *text, cons
 
 void cDisplay::DrawText(int x, int y, const char *text, int len, const enumTeletextColor cText) {
     // Copy text to teletext page
-    DEBUG_OT_DTXT("called with x=%d y=%d len=%d text='%s' strlen(text)=%ld", x, y, len, text, strlen(text));
+    DEBUG_OT_DTXT("called with x=%d y=%d len=%d text='%s' strlen(text)=%d", x, y, len, text, (int) strlen(text));
 
     cTeletextChar c;
     c.SetFGColor(cText); // default ttcWhite

--- a/menu.c
+++ b/menu.c
@@ -919,9 +919,9 @@ void TeletextBrowser::UpdateFooter() {
       DEBUG_OT_FOOT("AkRed=%d AkGreen=%d AkYellow=%d AkBlue=%d", AkRed, AkGreen, AkYellow, AkBlue);
 
 #define CONVERT_ACTION_TO_TEXT(text, mode) \
-      if (mode < 100) { \
+      if ((int) mode < 100) { \
          snprintf(text, sizeof(text), "%s", tr(st_modesFooter[mode])); \
-      } else if (mode < 999) { \
+      } else if ((int) mode < 999) { \
          snprintf(text, sizeof(text), "-> %03d", mode); \
       } else { \
          snprintf(text, sizeof(text), "ERROR"); \

--- a/menu.c
+++ b/menu.c
@@ -128,22 +128,22 @@ void TeletextBrowser::ChannelSwitched(int ChannelNumber, const bool live) {
       currentPage=(*it).second;
    }
 
-   char str[80];
-   Display::ClearPage();
-   if (liveChannelNumber != currentChannelNumber)
-      snprintf(str, sizeof(str), "%s %s: %s", tr("Switch to cached"), tr("Channel"), channelClass.Name());
-   else if (live)
-      snprintf(str, sizeof(str), "%s %s: %s", tr("Switch to live"), tr("Channel"), channelClass.Name());
-   else
-      snprintf(str, sizeof(str), "%s %s: %s", tr("Switch back to live"), tr("Channel"), channelClass.Name());
-
-   Display::DrawMessage(str, ttcBlue);
-   sleep(1);
-   
    //on the one hand this must work in background mode, when the plugin is not active.
    //on the other hand, if active, the page should be shown.
    //so this self-Pointer.
    if (self) {
+      char str[80];
+      Display::ClearPage();
+      if (liveChannelNumber != currentChannelNumber)
+         snprintf(str, sizeof(str), "%s %s: %s", tr("Switch to cached"), tr("Channel"), channelClass.Name());
+      else if (live)
+         snprintf(str, sizeof(str), "%s %s: %s", tr("Switch to live"), tr("Channel"), channelClass.Name());
+      else
+         snprintf(str, sizeof(str), "%s %s: %s", tr("Switch back to live"), tr("Channel"), channelClass.Name());
+
+      Display::DrawMessage(str, ttcBlue);
+      sleep(1);
+
       self->ShowPage();
    }
 }

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -115,6 +115,7 @@ protected:
 
 cPluginTeletextosd::cPluginTeletextosd(void)
   : txtStatus(0), startReceiver(true), storage(NULL), maxStorage(-1)
+    , storageSystem(Storage::StorageSystemPacked)
 {
   // Initialize any member variables here.
   // DON'T DO ANYTHING ELSE THAT MAY HAVE SIDE EFFECTS, REQUIRE GLOBAL

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -32,7 +32,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "2.0.0";
+static const char *VERSION        = "2.0.1";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 

--- a/setup.c
+++ b/setup.c
@@ -13,16 +13,16 @@
 
 const char *st_modes[] =
 {
-      trNOOP("Zoom"),
-      trNOOP("Half page"),
-      trNOOP("Change channel"),
-      trNOOP("Switch background"),
-      //trNOOP("Suspend receiving"),
-      trNOOP("Config"),
-      trNOOP("24-LineMode"),
-      trNOOP("Answer"),
-      trNOOP("Pause"),
-      trNOOP("Jump to..."),
+      tr("Zoom"),
+      tr("Half page"),
+      tr("Change channel"),
+      tr("Switch background"),
+      //tr("Suspend receiving"),
+      tr("Config"),
+      tr("24-LineMode"),
+      tr("Answer"),
+      tr("Pause"),
+      tr("Jump to..."),
 };
 
 const char *st_modesFooter[] =

--- a/txtrender.c
+++ b/txtrender.c
@@ -634,16 +634,19 @@ void cRenderPage::RenderTeletextCode(unsigned char *PageCode) {
 
                 x = addr;
                 cTeletextChar c = GetChar(x, y);
-                if (mode == 0x1000) {
+                if (mode == 0x10) {
+                    // 0x10 = 0b10000
                     info = "G0 character without diacritical mark";
-                    // No diacritical mark exists for mode description value 10000. An unmodified G0 character is then displayed unless the 7 bits of the data field have the value 0101010 (2/A) when the symbol "@" shall be displayed.
+                    // No diacritical mark exists for mode description value 0b10000. An unmodified G0 character is then displayed unless the 7 bits of the data field have the value 0b0101010 (2/A) when the symbol "@" shall be displayed.
                     if (data == 0x2a) {
                         // set char to '@'
+                        c.SetCharset(CHARSET_LATIN_G0);
                         c.SetChar(0x80);
                     } else {
+                        c.SetCharset(CHARSET_LATIN_G0);
                         c.SetChar(data);
                     };
-                    DEBUG_OT_TXTRDT("X/26 triplet found: row=%d triplet=%d: %s\n", row, triplet, info);
+                    DEBUG_OT_TXTRDT("X/26 triplet found: row=%d triplet=%d: %s (data=0x%02x)\n", row, triplet, info, data);
                     found = 1;
                 } else {
                     info = "G0 character with diacritical mark";

--- a/txtrender.c
+++ b/txtrender.c
@@ -623,7 +623,7 @@ void cRenderPage::RenderTeletextCode(unsigned char *PageCode) {
                     DEBUG_OT_TXTRDT("X/26 triplet found: row=%d triplet=%d TerminationMarker: %s\n", row, triplet, info);
                 };
             } else if (((mode & 0x10) == 0x10) && (addr >= 0) && (addr <= 39)) {
-                // 0x1x =  0b1xxxx
+                // 0x1x = 0b1xxxx
                 // G0 Characters Including Diacritical Marks
 
                 if (y == -1) {

--- a/txtrender.c
+++ b/txtrender.c
@@ -562,7 +562,7 @@ void cRenderPage::RenderTeletextCode(unsigned char *PageCode) {
         if (PageCode_X26[row*40] == 0) {
             // row empty
             continue;
-        } else if (PageCode_X26[row*40] & 0x80 != 0x80) {
+        } else if ((PageCode_X26[row*40] & 0x80) != 0x80) {
             DEBUG_OT_TXTRDT("invalid X/26 row (DesignationCode flag not valid)");
             continue;
         };


### PR DESCRIPTION
- fix warnings reported by clang
- display channel switch message only in case OSD is active
- fix G0 character without diacritical mark
- bring storage system "packed" back to default
