### PR TITLE
Milestone 2.1.0.regression.2

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,9 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
-2021-04-14: version 2.1.0
+2021-04-15:
+- [pbiering] finally catch and handle proper switching from tuned to live channel by outside trigger (e.g. RCU)
+
+2021-04-14:
 - [pbiering] replace all sleeps related to messages with a delay method, review/catch cases when a channel switch message should be displayed
 - [pbiering] include channel number in 'invalid channel' message
 - [pbiering] ChannelSwitch now supports receiving other channels from same transponder or even other transponder (aka "tuned" mode)

--- a/menu.c
+++ b/menu.c
@@ -168,6 +168,11 @@ void TeletextBrowser::ChannelSwitched(int ChannelNumber, const eChannelInfo info
             color = ttcMagenta;
          };
       }
+      else if (info == ChannelWasTunedNewChannelIsLive) {
+         // received trigger that TUNED channel has no longer a receiver but new would be a LIVE channel
+         // suppress a message which will be shortly overwritten anyhow by starting receiver on new channel
+         ChannelInfo = ChannelIsCached; // new status
+      }
       else if (info == ChannelWasTuned) {
          // received trigger that TUNED channel has no longer a receiver
          if (! switchChannelInProgress) {

--- a/menu.c
+++ b/menu.c
@@ -187,13 +187,6 @@ void TeletextBrowser::ChannelSwitched(int ChannelNumber, const eChannelInfo info
          // all cases catched
       };
 
-      // store for acting related on next call
-      infoLast = info;
-      ChannelNumberLast = ChannelNumber;
-
-      // clear status
-      switchChannelInProgress = false;
-
       self->ShowPage();
 
       if (strlen(str) > 0) {
@@ -201,6 +194,13 @@ void TeletextBrowser::ChannelSwitched(int ChannelNumber, const eChannelInfo info
          Display::DrawMessage(str, str2, color);
       };
    }
+
+   // store for acting related on next call
+   infoLast = info;
+   ChannelNumberLast = ChannelNumber;
+
+   // clear status
+   switchChannelInProgress = false;
 }
 
 

--- a/menu.h
+++ b/menu.h
@@ -26,6 +26,7 @@ enum eChannelInfo {
    ChannelIsTuned,
    ChannelIsCached,
    ChannelWasTuned,
+   ChannelWasTunedNewChannelIsLive,
    ChannelHasNoTeletext
 };
 

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -32,7 +32,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "2.1.0.beta.2";
+static const char *VERSION        = "2.1.0.reg.2";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 

--- a/txtrecv.h
+++ b/txtrecv.h
@@ -59,6 +59,7 @@ private:
    Storage *storage;
    const cDevice *device;
    const bool live;
+   bool flagStopByLiveChannelSwitch;
    const cChannel* channel;
    long int statTxtReceiverPageCount;
    time_t statTxtReceiverTimeStart;
@@ -74,6 +75,7 @@ public:
    cTxtReceiver(const cDevice *dev, const bool live, const cChannel* chan, bool storeTopText, Storage* storage);
    virtual ~cTxtReceiver();
    virtual void Stop();
+   void SetFlagStopByLiveChannelSwitch(bool flag) { flagStopByLiveChannelSwitch = flag; };
 };
 
 class cTxtStatus : public cStatus {


### PR DESCRIPTION
- finally catch and handle proper switching from tuned to live channel by outside trigger (e.g. RCU)
- minor debug extenstions and fixes