### PR TITLE
post 2.1.0 bugfixes

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,9 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
+2021-04-27: version 2.1.1
+- [pbiering] release receiver on live channel switch earlier in sequence to use even on 2-tuner systems by default only one tuner
+- [pbiering] release device on non-live -> non-live channel switch earlier to avoid locking on 2-tuner systems
+
 2021-04-19: version 2.1.0
 - [pbiering] catch case where in tuned mode channel switch is triggered on selected device and switch into cached mode
 

--- a/menu.c
+++ b/menu.c
@@ -245,7 +245,10 @@ bool TeletextBrowser::TriggerChannelSwitch(const int channelNumber) {
       needClearMessage = true;
       switchChannelInProgress = true;
       if (device->SwitchChannel(newChannel, (channelNumber == liveChannelNumber) ? true : false)) {
-         // Display::DrawMessage(tr("Channel Tuning Successful"), ttcGreen);
+         if (1 == 0) {
+            // too verbose - disabled
+            Display::DrawMessage(tr("Channel Tuning Successful"), ttcGreen);
+         };
          result = true;
          DEBUG_OT_TXTRCVC("DVB %d successful tuned to channel %d (live=%s)", device->DeviceNumber(), channelNumber, BOOLTOTEXT(channelNumber == liveChannelNumber));
       } else {
@@ -255,9 +258,12 @@ bool TeletextBrowser::TriggerChannelSwitch(const int channelNumber) {
          DEBUG_OT_TXTRCVC("DVB %d cannot tune to channel %d", device->DeviceNumber(), channelNumber);
       };
    } else {
-      needClearMessage = true;
-      delayClearMessage = 2;
-      Display::DrawMessage(tr("No Free Tuner Found - Use Cache Only"), ttcYellow);
+      if (1 == 0) {
+         // too verbose - disabled
+         needClearMessage = true;
+         delayClearMessage = 2;
+         Display::DrawMessage(tr("No Free Tuner Found - Use Cache Only"), ttcYellow);
+      };
       DEBUG_OT_TXTRCVC("no free tuner available to tune to channel %d (use cache)", channelNumber);
       ChannelSwitched(channelNumber, ChannelIsCached);
    };

--- a/menu.c
+++ b/menu.c
@@ -234,6 +234,7 @@ bool TeletextBrowser::TriggerChannelSwitch(const int channelNumber) {
             DEBUG_OT_TXTRCVC("requested channel %d is LIVE channel, running receiver found on NON-LIVE channel %d - action will be triggered later", channelNumber, liveChannelNumber);
          } else {
             DEBUG_OT_TXTRCVC("requested channel %d is NON-LIVE channel, running receiver found on NON-LIVE channel %d - stop receiver to release device", channelNumber, liveChannelNumber);
+            switchChannelInProgress = true;
             DELETENULL(txtStatus->receiver);
          };
       };

--- a/menu.c
+++ b/menu.c
@@ -192,7 +192,7 @@ void TeletextBrowser::ChannelSwitched(int ChannelNumber, const eChannelInfo info
          // all cases catched
       };
 
-      self->ShowPage();
+      self->ShowPage((strlen(str) > 0));
 
       if (strlen(str) > 0) {
          self->needClearMessage=true;
@@ -944,8 +944,8 @@ void TeletextBrowser::SetPreviousPage(int oldPage, int oldSubPage, int newPage) 
 
 
 
-void TeletextBrowser::ShowPage() {
-   if ((pageFound=DecodePage())) {
+void TeletextBrowser::ShowPage(bool suppressMessage) {
+   if ((pageFound=DecodePage(suppressMessage))) {
       if (ttSetup.autoUpdatePage)
          checkSum=PageCheckSum();
    }
@@ -981,7 +981,7 @@ void TeletextBrowser::ShowAskForChannel() {
 }
 
 //this is taken and adapted from the teletext plugin since it uses its data
-bool TeletextBrowser::DecodePage() {
+bool TeletextBrowser::DecodePage(bool suppressMessage) {
    // Load the page and decodes it
    unsigned char cache[sizeof(TelePageData)];
    StorageHandle fd;
@@ -1037,8 +1037,10 @@ bool TeletextBrowser::DecodePage() {
             color = ttcRed;
          };
       };
-      needClearMessage = false;
-      Display::DrawMessage(str, str2, color);
+      if (! suppressMessage) {
+         needClearMessage = false;
+         Display::DrawMessage(str, str2, color);
+      };
       UpdateFooter();
       Display::ReleaseFlush();
 

--- a/menu.c
+++ b/menu.c
@@ -228,15 +228,18 @@ bool TeletextBrowser::TriggerChannelSwitch(const int channelNumber) {
       if (device->SwitchChannel(newChannel, (channelNumber == liveChannelNumber) ? true : false)) {
          // Display::DrawMessage(tr("Channel Tuning Successful"), ttcGreen);
          result = true;
+         DEBUG_OT_TXTRCVC("DVB %d successful tuned to channel %d (live=%s)", device->DeviceNumber(), channelNumber, BOOLTOTEXT(channelNumber == liveChannelNumber));
       } else {
          needClearMessage = true;
          delayClearMessage = 5;
          Display::DrawMessage(tr("Channel Tuning Not Successful"), ttcRed);
+         DEBUG_OT_TXTRCVC("DVB %d cannot tune to channel %d", device->DeviceNumber(), channelNumber);
       };
    } else {
       needClearMessage = true;
       delayClearMessage = 2;
       Display::DrawMessage(tr("No Free Tuner Found - Use Cache Only"), ttcYellow);
+      DEBUG_OT_TXTRCVC("no free tuner available to tune to channel %d (use cache)", channelNumber);
       ChannelSwitched(channelNumber, ChannelIsCached);
    };
 

--- a/menu.c
+++ b/menu.c
@@ -221,6 +221,24 @@ bool TeletextBrowser::TriggerChannelSwitch(const int channelNumber) {
 #endif
    if (!newChannel) return false;
 
+   if (txtStatus->receiver) {
+      // receiver is already running
+      if (txtStatus->receiver->Live()) {
+         if (channelNumber == liveChannelNumber) {
+            DEBUG_OT_TXTRCVC("requested channel %d is LIVE channel, running receiver found on LIVE channel %d - not action required", channelNumber, liveChannelNumber);
+         } else {
+            DEBUG_OT_TXTRCVC("requested channel %d is NON-LIVE channel, running receiver found on LIVE channel %d - action will be triggered later", channelNumber, liveChannelNumber);
+         };
+      } else {
+         if (channelNumber == liveChannelNumber) {
+            DEBUG_OT_TXTRCVC("requested channel %d is LIVE channel, running receiver found on NON-LIVE channel %d - action will be triggered later", channelNumber, liveChannelNumber);
+         } else {
+            DEBUG_OT_TXTRCVC("requested channel %d is NON-LIVE channel, running receiver found on NON-LIVE channel %d - stop receiver to release device", channelNumber, liveChannelNumber);
+            DELETENULL(txtStatus->receiver);
+         };
+      };
+   };
+
    cDevice *device = cDevice::GetDeviceForTransponder(newChannel, TRANSFERPRIORITY - 1);
    if (device != NULL) {
       needClearMessage = true;

--- a/menu.h
+++ b/menu.h
@@ -40,10 +40,10 @@ public:
 protected:
    enum Direction { DirectionForward, DirectionBackward };
    void SetNumber(int i);
-   void ShowPage();
+   void ShowPage(bool suppressMessage = false);
    void UpdateClock();
    void UpdateFooter();
-   bool DecodePage();
+   bool DecodePage(bool suppressMessage = false);
    void ChangePageRelative(Direction direction);
    void ChangeSubPageRelative(Direction direction);
    bool CheckPage();

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -32,7 +32,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "2.1.0";
+static const char *VERSION        = "2.1.1";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 

--- a/po/ca_ES.po
+++ b/po/ca_ES.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-19 07:48+0200\n"
+"POT-Creation-Date: 2021-04-27 19:28+0200\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Jordi Vilà <jvila@tinet.org>\n"
 "Language-Team: Catalan <vdr@linuxtv.org>\n"
@@ -49,6 +49,9 @@ msgid "display cached pages"
 msgstr ""
 
 msgid "cached"
+msgstr ""
+
+msgid "Channel Tuning Successful"
 msgstr ""
 
 msgid "Channel Tuning Not Successful"

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 2.4.4\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-19 07:20+0200\n"
+"POT-Creation-Date: 2021-04-27 19:28+0200\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Peter Bieringer <pb@bieringer.de>\n"
 "Language-Team: German <vdr@linuxtv.org>\n"
@@ -48,6 +48,9 @@ msgstr "zeige gespeicherte Seiten an"
 
 msgid "cached"
 msgstr "gespeicherten"
+
+msgid "Channel Tuning Successful"
+msgstr "Kanal erfolgreich eingestellt"
 
 msgid "Channel Tuning Not Successful"
 msgstr "Kanal nicht erfolgreich eingestellt"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-19 07:48+0200\n"
+"POT-Creation-Date: 2021-04-27 19:28+0200\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Ruben Nunez Francisco <ruben.nunez@tang-it.com>\n"
 "Language-Team: Spanish <vdr@linuxtv.org>\n"
@@ -47,6 +47,9 @@ msgid "display cached pages"
 msgstr ""
 
 msgid "cached"
+msgstr ""
+
+msgid "Channel Tuning Successful"
 msgstr ""
 
 msgid "Channel Tuning Not Successful"

--- a/po/fi_FI.po
+++ b/po/fi_FI.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-19 07:48+0200\n"
+"POT-Creation-Date: 2021-04-27 19:28+0200\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Rolf Ahrenberg <rahrenbe@cc.hut.fi>\n"
 "Language-Team: Finnish <vdr@linuxtv.org>\n"
@@ -47,6 +47,9 @@ msgid "display cached pages"
 msgstr ""
 
 msgid "cached"
+msgstr ""
+
+msgid "Channel Tuning Successful"
 msgstr ""
 
 msgid "Channel Tuning Not Successful"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-19 07:48+0200\n"
+"POT-Creation-Date: 2021-04-27 19:28+0200\n"
 "PO-Revision-Date: 2009-01-10 19:32+0100\n"
 "Last-Translator: Nival Michaël\n"
 "Language-Team: French <vdr@linuxtv.org>\n"
@@ -50,6 +50,9 @@ msgid "display cached pages"
 msgstr ""
 
 msgid "cached"
+msgstr ""
+
+msgid "Channel Tuning Successful"
 msgstr ""
 
 msgid "Channel Tuning Not Successful"

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-19 07:48+0200\n"
+"POT-Creation-Date: 2021-04-27 19:28+0200\n"
 "PO-Revision-Date: 2010-11-06 19:59+0100\n"
 "Last-Translator: Diego Pierotto <vdr-italian@tiscali.it>\n"
 "Language-Team: Italian <vdr@linuxtv.org>\n"
@@ -54,6 +54,9 @@ msgid "display cached pages"
 msgstr ""
 
 msgid "cached"
+msgstr ""
+
+msgid "Channel Tuning Successful"
 msgstr ""
 
 msgid "Channel Tuning Not Successful"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-19 07:48+0200\n"
+"POT-Creation-Date: 2021-04-27 19:28+0200\n"
 "PO-Revision-Date: 2008-05-04 15:33+0200\n"
 "Last-Translator: Chris Silva <hudokkow@gmail.com>\n"
 "Language-Team: Portuguese <vdr@linuxtv.org>\n"
@@ -47,6 +47,9 @@ msgid "display cached pages"
 msgstr ""
 
 msgid "cached"
+msgstr ""
+
+msgid "Channel Tuning Successful"
 msgstr ""
 
 msgid "Channel Tuning Not Successful"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-19 07:48+0200\n"
+"POT-Creation-Date: 2021-04-27 19:28+0200\n"
 "PO-Revision-Date: 2008-12-30 13:52+0100\n"
 "Last-Translator: Andrey Pridvorov <ua0lnj@bk.ru>\n"
 "Language-Team: Russian <vdr@linuxtv.org>\n"
@@ -48,6 +48,9 @@ msgid "display cached pages"
 msgstr ""
 
 msgid "cached"
+msgstr ""
+
+msgid "Channel Tuning Successful"
 msgstr ""
 
 msgid "Channel Tuning Not Successful"

--- a/po/sk_SK.po
+++ b/po/sk_SK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: osdteletext-0.9.0\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-19 07:48+0200\n"
+"POT-Creation-Date: 2021-04-27 19:28+0200\n"
 "PO-Revision-Date: 2011-02-15 21:11+0100\n"
 "Last-Translator: Milan Hrala <hrala.milan@gmail.com>\n"
 "Language-Team: Slovak <hrala.milan@gmail.com>\n"
@@ -47,6 +47,9 @@ msgid "display cached pages"
 msgstr ""
 
 msgid "cached"
+msgstr ""
+
+msgid "Channel Tuning Successful"
 msgstr ""
 
 msgid "Channel Tuning Not Successful"

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR 1.5.7\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2021-04-19 07:48+0200\n"
+"POT-Creation-Date: 2021-04-27 19:28+0200\n"
 "PO-Revision-Date: 2009-05-25 20:33+0200\n"
 "Last-Translator: Yarema P. aka Knedlyk <yupadmin@gmail.com>\n"
 "Language-Team: Ukrainian <vdr@linuxtv.org>\n"
@@ -47,6 +47,9 @@ msgid "display cached pages"
 msgstr ""
 
 msgid "cached"
+msgstr ""
+
+msgid "Channel Tuning Successful"
 msgstr ""
 
 msgid "Channel Tuning Not Successful"

--- a/txtrecv.c
+++ b/txtrecv.c
@@ -216,7 +216,18 @@ void cTxtStatus::ChannelSwitch(const cDevice *Device, int ChannelNumber, bool Li
 {
    // ignore if channel is 0
    if (ChannelNumber == 0) {
-      DEBUG_OT_TXTRCVC("IGNORE channel=0 switch on DVB %d for channel %d LiveView=%s\n", Device->DeviceNumber(), ChannelNumber, BOOLTOTEXT(LiveView));
+      if (LiveView && receiver) {
+         if (receiver->Live()) {
+            DEBUG_OT_TXTRCVC("STOPRC channel=0 switch on DVB %d for channel %d LiveView=%s (receiver is attached to LIVE channel)\n", Device->DeviceNumber(), ChannelNumber, BOOLTOTEXT(LiveView));
+            DELETENULL(receiver);
+            return;
+         } else {
+            DEBUG_OT_TXTRCVC("IGNORE channel=0 switch on DVB %d for channel %d LiveView=%s (receiver is attached to NON-LIVE channel)\n", Device->DeviceNumber(), ChannelNumber, BOOLTOTEXT(LiveView));
+            return;
+         };
+      } else {
+         DEBUG_OT_TXTRCVC("IGNORE channel=0 switch on DVB %d for channel %d LiveView=%s\n", Device->DeviceNumber(), ChannelNumber, BOOLTOTEXT(LiveView));
+      };
       return;
    };
 
@@ -276,7 +287,7 @@ void cTxtStatus::ChannelSwitch(const cDevice *Device, int ChannelNumber, bool Li
       receiver->SetFlagStopByLiveChannelSwitch(true);
    };
 
-   // channel was changed, delete the running receiver
+   // channel was changed, delete the running receiver if still running
    DELETENULL(receiver);
 
    if (TPid) {

--- a/txtrecv.h
+++ b/txtrecv.h
@@ -79,11 +79,13 @@ public:
    virtual void Stop();
    void SetFlagStopByLiveChannelSwitch(bool flag) { flagStopByLiveChannelSwitch = flag; };
    bool Live() { return live; };
+   bool ChannelNumber() { return channel->Number(); };
 };
 
 class cTxtStatus : public cStatus {
-private:
+public:
    cTxtReceiver *receiver;
+private:
    bool storeTopText;
    Storage* storage;
    int NonLiveChannelNumber;

--- a/txtrecv.h
+++ b/txtrecv.h
@@ -78,6 +78,7 @@ public:
    virtual ~cTxtReceiver();
    virtual void Stop();
    void SetFlagStopByLiveChannelSwitch(bool flag) { flagStopByLiveChannelSwitch = flag; };
+   bool Live() { return live; };
 };
 
 class cTxtStatus : public cStatus {


### PR DESCRIPTION
- release receiver on live channel switch earlier in sequence to use even on 2-tuner systems by default only one tuner
- release device on non-live -> non-live channel switch earlier to avoid locking on 2-tuner systems
