### PR TITLE
2.2.0.beta.2

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,9 @@
 VDR Plugin 'osdteletext' Revision History
 -----------------------------------------
+2021-05-22:
+- [pbiering] fix range check bug related to Hotkey "jump to page" config
+- [pbiering] fix not working Hotkey level feature in case only 2 levels are active
+
 2021-05-12:
 - [pbiering] fix in setup changed but not applied to current background transparency
 

--- a/menu.c
+++ b/menu.c
@@ -707,7 +707,7 @@ void TeletextBrowser::ExecuteAction(eTeletextAction e) {
             break;
          };
 
-         if (ttSetup.hotkeyLevelMax <= 2) {
+         if (ttSetup.hotkeyLevelMax < 2) {
             // HotkeyLevel not active by setup limit to 1
             needClearMessage=true;
             delayClearMessage = 3;

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -32,7 +32,7 @@ using namespace std;
 
 #define NUMELEMENTS(x) (sizeof(x) / sizeof(x[0]))
 
-static const char *VERSION        = "2.2.0.beta.1";
+static const char *VERSION        = "2.2.0.beta.2";
 static const char *DESCRIPTION    = trNOOP("Displays teletext on the OSD");
 static const char *MAINMENUENTRY  = trNOOP("Teletext");
 

--- a/osdteletext.c
+++ b/osdteletext.c
@@ -637,7 +637,11 @@ bool cPluginTeletextosd::SetupParse(const char *Name, const char *Value)
         int v;
         CHECK_SETUP_STRING_COND_SUFFIX(Name, cTeletextSetupPage::actionHotkeyNames[i].internalName, l, HOTKEY_LEVEL_MAX_LIMIT);
         if (l >= 0) {
-           CHECK_STORE_INT_VALUE(v, Value, 0, ((int) LastAction) - 1);
+           CHECK_STORE_INT_VALUE(v, Value, 0, 999);
+           if ((v < 100) && (v >= (int) LastAction)) {
+              esyslog("osdteletext: ignore entry with out-of-range value in setup.conf: osdteletext.%s (%d)", Name, v);
+              return true;
+           };
            ttSetup.mapHotkeyToAction[i][l] = (eTeletextAction) v;
            return true;
         };


### PR DESCRIPTION
- fix range check bug related to Hotkey "jump to page" config
- fix not working Hotkey level feature in case only 2 levels are active

Closing https://github.com/vdr-projects/vdr-plugin-osdteletext/issues/61
